### PR TITLE
Stats: add promoted, gen size, reason, and overall heap output when pressing s

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,22 +34,27 @@ C:\realmon\src\windows\bin\x64\Release\net5.0>GCRealTimeMon -n devenv
 Example output:
 
 ```
--------press any key to exit ☺-------
+------- press s for current stats or any other key to exit -------
 
-Monitoring process with name: devenv and pid: 1932
-
-GC#     index |            type |   gen | pause (ms)
-----------------------------------------------------
-
-GC#       674 | NonConcurrentGC |     1 |       7.24
-GC#       675 | NonConcurrentGC |     1 |      17.29
-GC#       676 | NonConcurrentGC |     1 |       9.33
-GC#       677 | NonConcurrentGC |     1 |      22.98
-GC#       678 | NonConcurrentGC |     1 |      20.00
-GC#       679 | NonConcurrentGC |     1 |      14.12
-GC#       680 | NonConcurrentGC |     1 |      10.58
-GC#       681 | NonConcurrentGC |     1 |       4.94
-GC#       682 | NonConcurrentGC |     1 |      12.43
+Monitoring process with name: Samples.AspNet5 and pid: 45044
+GC#     index |            type |   gen | pause (ms) |                reason |
+------------------------------------------------------------------------------
+GC#         1 | NonConcurrentGC |     0 |       7.45 |            AllocSmall |
+GC#         2 | NonConcurrentGC |     1 |      17.88 |            AllocSmall |
+GC#         3 | NonConcurrentGC |     0 |       3.20 |            AllocSmall |
+------------------------------------------------------------------------------
+Heap Stats as of 2021-11-08 03:15:30Z (Run 1 for gen 0):
+  Heaps: 16
+  Handles: 2,015
+  Pinned Obj Count: 8
+  Last Run Stats:
+    Total Heap: 15,846,992 Bytes
+      Gen 0:               384 Bytes
+      Gen 1:        10,718,432 Bytes
+      Gen 2:               384 Bytes
+      Gen 3:         4,358,056 Bytes
+      Gen 4:           769,736 Bytes
+------------------------------------------------------------------------------
 ```
 
 **Building**

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Right now it's super simple - given a PID or process name it will show you a few
 
 Note: Either the name of the process or the process id must be specified, else an ``ArgumentException`` is thrown.
 
+## Runtime Keys
+
+| Key | Action |
+|-----|-----|
+| `s` | Prints detailed stats of the last collection and the state of each generation |
+
 ## Example Usage
 
 ```

--- a/src/windows/Program.cs
+++ b/src/windows/Program.cs
@@ -34,8 +34,8 @@ namespace realmon
         }
 
         static TraceEventSession session;
-        static DateTime lastTraceTime;
-        static TraceGC lastTrace;
+        static DateTime lastGCTime;
+        static TraceGC lastGC;
         static object writerLock = new object();
 
         public static void RealTimeProcessing(string processName, double? minDurationForGCPausesInMSec)
@@ -85,8 +85,8 @@ namespace realmon
                                 if (!minDurationForGCPausesInMSec.HasValue ||
                                    (minDurationForGCPausesInMSec.HasValue && minDurationForGCPausesInMSec.Value < gc.PauseDurationMSec))
                                 {
-                                    lastTraceTime = DateTime.UtcNow;
-                                    lastTrace = gc;
+                                    lastGCTime = DateTime.UtcNow;
+                                    lastGC = gc;
 
                                     var stats = gc.HeapStats;
                                     var genPromoted = gc.Generation switch {
@@ -130,18 +130,18 @@ namespace realmon
 
         private static void PrintLastStats()
         {
-            if (lastTrace == null)
+            if (lastGC == null)
             {
                 Console.WriteLine("No stats collected yet.");
             }
             else 
             {
-                var t = lastTrace; // capture, since this could tear
+                var t = lastGC; // capture, since this could tear
                 var s = t.HeapStats;
                 lock (writerLock)
                 {
                     Console.WriteLine(LineSeparator);
-                    Console.WriteLine("Heap Stats as of {0:u} (Run {1} for gen {2}):", lastTraceTime, t.Number, t.Generation);
+                    Console.WriteLine("Heap Stats as of {0:u} (Run {1} for gen {2}):", lastGCTime, t.Number, t.Generation);
                     Console.WriteLine("  Heaps: {0:N0}", t.HeapCount);
                     Console.WriteLine("  Handles: {0:N0}", s.GCHandleCount);
                     Console.WriteLine("  Pinned Obj Count: {0:N0}", s.PinnedObjectCount);

--- a/src/windows/Program.cs
+++ b/src/windows/Program.cs
@@ -52,14 +52,14 @@ namespace realmon
             }
         }
 
-        private const string LineSeparator = "--------------------------------------------------------------------------------------------------------";
+        private const string LineSeparator = "------------------------------------------------------------------------------";
 
         public static void RealTimeProcessing(int pid, double? minDurationForGCPausesInMSec)
         {
             Console.WriteLine();
             Process process = Process.GetProcessById(pid);
             Console.WriteLine($"Monitoring process with name: {process.ProcessName} and pid: {pid}");
-            Console.WriteLine("GC#{0,10} | {1,15} | {2,5} | {3,10} | {4,10} | {5,10} | {6, 21} |", "index", "type", "gen", "pause (ms)", "promoted", "gen size", "reason");
+            Console.WriteLine("GC#{0,10} | {1,15} | {2,5} | {3,10} | {4, 21} |", "index", "type", "gen", "pause (ms)", "reason");
             Console.WriteLine(LineSeparator);
 
             session = new TraceEventSession("MySession");
@@ -88,32 +88,12 @@ namespace realmon
                                     lastGCTime = DateTime.UtcNow;
                                     lastGC = gc;
 
-                                    var stats = gc.HeapStats;
-                                    var genPromoted = gc.Generation switch {
-                                        0 => stats.TotalPromotedSize0,
-                                        1 => stats.TotalPromotedSize1,
-                                        2 => stats.TotalPromotedSize2,
-                                        3 => stats.TotalPromotedSize3,
-                                        4 => stats.TotalPromotedSize4,
-                                        _ => 0,
-                                    };
-                                    var genSize = gc.Generation switch {
-                                        0 => stats.GenerationSize0,
-                                        1 => stats.GenerationSize1,
-                                        2 => stats.GenerationSize2,
-                                        3 => stats.GenerationSize3,
-                                        4 => stats.GenerationSize4,
-                                        _ => 0
-                                    };
-
                                     lock (writerLock) {
-                                        Console.WriteLine("GC#{0,10} | {1,15} | {2,5} | {3,10:N2} | {4,10} | {5,10} | {6, 21} |",
+                                        Console.WriteLine("GC#{0,10} | {1,15} | {2,5} | {3,10:N2} | {4, 21} |",
                                             gc.Number, 
                                             gc.Type, 
                                             gc.Generation, 
                                             gc.PauseDurationMSec,
-                                            $"{(genPromoted / 1048576m):N2} MB",
-                                            $"{(genSize / 1048576m):N2} MB",
                                             gc.Reason);
                                     }
                                 }


### PR DESCRIPTION
Totally take it if you want, I can slice off pieces that are wanted, or close if not the right direction - no worries at all. Either way, thanks for this!

Overall I often want to see the state across heaps w.r.t. size so I tweaked this to output that if a user hits s while running. This adds promoted, gen size, and reason for the collection to the existing output but also adds the ability to hit s to get a breakdown of the current heaps (as of the last collection). Example run:
```
➜ dotnet run -- -p 45044
------- press s for current stats or any other key to exit -------

Monitoring process with name: Samples.AspNet5 and pid: 45044
GC#     index |            type |   gen | pause (ms) |                reason |
------------------------------------------------------------------------------
GC#         1 | NonConcurrentGC |     0 |       7.45 |            AllocSmall |
------------------------------------------------------------------------------
Heap Stats as of 2021-11-08 03:15:30Z (Run 1 for gen 0):
  Heaps: 16
  Handles: 2,015
  Pinned Obj Count: 8
  Last Run Stats:
    Total Heap: 15,846,992 Bytes
      Gen 0:               384 Bytes
      Gen 1:        10,718,432 Bytes
      Gen 2:               384 Bytes
      Gen 3:         4,358,056 Bytes
      Gen 4:           769,736 Bytes
------------------------------------------------------------------------------
```

Total changes:
- Minor cleanup to initial message
- Adds promoted, gen size, and reason to the existing output
- Hitting `s` now prints last stats (if any collected yet, a short message if not)
- Hitting a key _actually_ exits now - it took keys + enter previously with `.ReadLine()`
- Locks around multi-line console writing to prevent tearing (little contention here, just in case!)