### PR TITLE
Added all the columns that are in the GCStats view in PerfView.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,44 @@ The configuration file is a YAML based file currently with the following section
 
 Currently, the available columns are:
 
-| Column Name | Full Name | Trace Event Property |
-|-----|-----|-----|
-| index | The GC Number | ``TraceGC.Number``
-| gen | The Generation | ``TraceGC.Generation``  
-| type | The Type of GC | ``TraceGC.Type`` 
-| pause (ms) | Pause Duration in Msc | ``TraceGC.PauseDurationMSec``
-| reason | Reason for GC | ``TraceGC.Reason`` 
+| Column Name | Full Name / Description | Trace Event Property |
+|-------------|-------------------------|----------------------|
+| index | The GC Index. | ``TraceGC.Number``
+| gen | The Generation. | ``TraceGC.Generation``
+| type | The Type of GC. | ``TraceGC.Type``
+| pause (ms) | The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap.  For background GCs this is small. | ``TraceGC.PauseDurationMSec``
+| reason | Reason for GC. | ``TraceGC.Reason``
+| suspension time (ms) | The time in milliseconds that it took to suspend all threads to start this GC.  For background GCs, we pause multiple times, so this value may be higher than for foreground GCs. | ``TraceGC.SuspendDurationMSec``
+| pause time % since last GC | The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap.  For background GCs this is small | ``TraceGC.PauseTimePercentageSinceLastGC``
+| percent time in GC | Since the last GC, GC pause time expressed as a percentage of total process time.  For background GC, this includes the pause time for foreground GCs that occur during the background GC.| ``TraceGC.PercentTimeInGC``
+| amount allocated in gen 0 | Amount allocated since the last GC occurred. | ``TraceGC.UserAllocated[(int)Gens.Gen0]``
+| gen0 allocation rate | The average allocation rate since the last GC. | ``(TraceGC.UserAllocated[(int)Gens.Gen0] * 1000.0) / TraceGC.DurationSinceLastRestartMSec``
+| peak | The peak size of the GC during GC. | ``TraceGC.HeapSizePeakMB``
+| size at end of this GC | The size after GC (includes fragmentation) |  ``TraceGC.HeapSizeAfterMB``
+| ratio of end/beginning | Peak / After | ``TraceGC.HeapSizePeakMB / TraceGC.HeapSizePeakMB``
+| memory this gc promoted | Memory this GC promoted | ``TraceGC.PromotedMB``
+| gen0 size at end of this GC | Size of gen0 at the end of this GC. | ``TraceGC.GenSizeAfterMB(Gens.Gen0)``
+| gen0 survival rate | The % of objects in Gen0 that survived this GC. | ``TraceGC.SurvivalPercent(Gens.Gen0)``
+| gen0 frag ratio | The % of free space on gen0. | ``TraceGC.GenFragmentationPercent(Gens.Gen0)``
+| gen1 size at end of this GC | Size of gen1 at the end of this GC. | ``TraceGC.GenSizeAfterMB(Gens.Gen1)``
+| gen1 survival rate | The % of objects in Gen1 that survived this GC. Only available if we are doing a gen1 GC. | ``TraceGC.SurvivalPercent(Gens.Gen1)``
+| gen1 frag ratio | The % of free space on Gen1 that is between live objects. | ``TraceGC.GenFragmentationPercent(Gens.Gen1)``
+| gen2 size at end of this GC | Size of Gen2 in MB at the end of this GC. | ``TraceGC.GenSizeAfterMB(Gens.Gen2)``
+| gen2 survival rate |The % of objects in Gen2 that survived this GC. Only available if we are doing a gen2 GC. | ``TraceGC.SurvivalPercent(Gens.Gen2)``
+| gen2 frag ratio |The % of free space on gen2. | ``TraceGC.GenFragmentationPercent(Gens.Gen2)``
+| genlargeobj size at end of this GC | Size of Large object heap (LOH) in MB at the end of this GC. | ``TraceGC.GenSizeAfterMB(Gens.LargeObj)``
+| genlargeobj survival rate | The % of objects in the large object heap (LOH) that survived the GC. Only available if we are doing a gen2 GC. | ``TraceGC.SurvivalPercent(Gens.LargeObj)``
+| genlargeobj frag ratio | The % of free space that is between live objects on the large object heap (LOH) | ``TraceGC.GenFragmentationPercent(Gens.LargeObj)``
+| finalize promoted for GC | The number of MB of objects that have finalizers (destructors) that survived this GC. |  ``TraceGC.HeapStats.FinalizationPromotedSize / 1000000.0``
+| no. of pinned objects for GC | Number of pinned objects this GC promoted. | ``TraceGC.HeapStats.PinnedObjectCount``
 
 ## Unit Tests
 
-The unit tests are in the ``test`` directory.
+The unit tests are in the ``test`` directory and can be run by:
+
+```
+dotnet test
+```
 
 ## Adding New Columns
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Currently, the available columns are:
 | pause (ms) | The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap.  For background GCs this is small. | ``TraceGC.PauseDurationMSec``
 | reason | Reason for GC. | ``TraceGC.Reason``
 | suspension time (ms) | The time in milliseconds that it took to suspend all threads to start this GC.  For background GCs, we pause multiple times, so this value may be higher than for foreground GCs. | ``TraceGC.SuspendDurationMSec``
-| pause time % since last GC | The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap.  For background GCs this is small | ``TraceGC.PauseTimePercentageSinceLastGC``
-| percent time in GC | Since the last GC, GC pause time expressed as a percentage of total process time.  For background GC, this includes the pause time for foreground GCs that occur during the background GC.| ``TraceGC.PercentTimeInGC``
+| pause time % since last GC | Since the last GC, GC pause time expressed as a percentage of total process time.  For background GC, this includes the pause time for foreground GCs that occur during the background GC. | ``TraceGC.PauseTimePercentageSinceLastGC``
+| percent time in GC | Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage.| ``TraceGC.PercentTimeInGC``
 | amount allocated in gen 0 | Amount allocated since the last GC occurred. | ``TraceGC.UserAllocated[(int)Gens.Gen0]``
 | gen0 allocation rate | The average allocation rate since the last GC. | ``(TraceGC.UserAllocated[(int)Gens.Gen0] * 1000.0) / TraceGC.DurationSinceLastRestartMSec``
 | peak | The peak size of the GC during GC. | ``TraceGC.HeapSizePeakMB``

--- a/README.md
+++ b/README.md
@@ -66,44 +66,35 @@ The configuration file is a YAML based file currently with the following section
 
 Currently, the available columns are:
 
-| Column Name | Full Name / Description | Trace Event Property |
-|-------------|-------------------------|----------------------|
+| Column Name            | Full Name / Description                                                                                                                                                         | Trace Event Property                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | index | The GC Index. | ``TraceGC.Number``
 | gen | The Generation. | ``TraceGC.Generation``
 | type | The Type of GC. | ``TraceGC.Type``
-| pause (ms) | The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap.  For background GCs this is small. | ``TraceGC.PauseDurationMSec``
 | reason | Reason for GC. | ``TraceGC.Reason``
-| suspension time (ms) | The time in milliseconds that it took to suspend all threads to start this GC.  For background GCs, we pause multiple times, so this value may be higher than for foreground GCs. | ``TraceGC.SuspendDurationMSec``
-| pause time % since last GC | Since the last GC, GC pause time expressed as a percentage of total process time.  For background GC, this includes the pause time for foreground GCs that occur during the background GC. | ``TraceGC.PauseTimePercentageSinceLastGC``
-| percent time in GC | Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage.| ``TraceGC.PercentTimeInGC``
-| amount allocated in gen 0 | Amount allocated since the last GC occurred. | ``TraceGC.UserAllocated[(int)Gens.Gen0]``
-| gen0 allocation rate | The average allocation rate since the last GC. | ``(TraceGC.UserAllocated[(int)Gens.Gen0] * 1000.0) / TraceGC.DurationSinceLastRestartMSec``
-| peak | The peak size of the GC during GC. | ``TraceGC.HeapSizePeakMB``
-| size at end of this GC | The size after GC (includes fragmentation) |  ``TraceGC.HeapSizeAfterMB``
-| ratio of end/beginning | Peak / After | ``TraceGC.HeapSizePeakMB / TraceGC.HeapSizePeakMB``
-| memory this gc promoted | Memory this GC promoted | ``TraceGC.PromotedMB``
-| gen0 size at end of this GC | Size of gen0 at the end of this GC. | ``TraceGC.GenSizeAfterMB(Gens.Gen0)``
-| gen0 survival rate | The % of objects in Gen0 that survived this GC. | ``TraceGC.SurvivalPercent(Gens.Gen0)``
-| gen0 frag ratio | The % of free space on gen0. | ``TraceGC.GenFragmentationPercent(Gens.Gen0)``
-| gen1 size at end of this GC | Size of gen1 at the end of this GC. | ``TraceGC.GenSizeAfterMB(Gens.Gen1)``
-| gen1 survival rate | The % of objects in Gen1 that survived this GC. Only available if we are doing a gen1 GC. | ``TraceGC.SurvivalPercent(Gens.Gen1)``
-| gen1 frag ratio | The % of free space on Gen1 that is between live objects. | ``TraceGC.GenFragmentationPercent(Gens.Gen1)``
-| gen2 size at end of this GC | Size of Gen2 in MB at the end of this GC. | ``TraceGC.GenSizeAfterMB(Gens.Gen2)``
-| gen2 survival rate |The % of objects in Gen2 that survived this GC. Only available if we are doing a gen2 GC. | ``TraceGC.SurvivalPercent(Gens.Gen2)``
-| gen2 frag ratio |The % of free space on gen2. | ``TraceGC.GenFragmentationPercent(Gens.Gen2)``
-| genlargeobj size at end of this GC | Size of Large object heap (LOH) in MB at the end of this GC. | ``TraceGC.GenSizeAfterMB(Gens.LargeObj)``
-| genlargeobj survival rate | The % of objects in the large object heap (LOH) that survived the GC. Only available if we are doing a gen2 GC. | ``TraceGC.SurvivalPercent(Gens.LargeObj)``
-| genlargeobj frag ratio | The % of free space that is between live objects on the large object heap (LOH) | ``TraceGC.GenFragmentationPercent(Gens.LargeObj)``
-| finalize promoted for GC | The number of MB of objects that have finalizers (destructors) that survived this GC. |  ``TraceGC.HeapStats.FinalizationPromotedSize / 1000000.0``
-| no. of pinned objects for GC | Number of pinned objects this GC promoted. | ``TraceGC.HeapStats.PinnedObjectCount``
-
-## Unit Tests
-
-The unit tests are in the ``test`` directory and can be run by:
-
-```
-dotnet test
-```
+| suspension time (ms)   | The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs. | `TraceGC.SuspendDurationMSec`                                                             |
+| pause time (%)           | The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small.                                   | `TraceGC.PauseTimePercentageSinceLastGC`                                                  |
+| CPU time (%)             | Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage.                                                                              | `TraceGC.PercentTimeInGC`                                                                 |
+| gen0 alloc (mb)        | Amount allocated in Gen0 since the last GC occurred in MB.                                                                                                                       | `TraceGC.UserAllocated[(int)Gens.Gen0]`                                                   |
+| gen0 alloc rate        | The average allocation rate since the last GC.                                                                                                                                   | `(TraceGC.UserAllocated[(int)Gens.Gen0] * 1000.0) / TraceGC.DurationSinceLastRestartMSec` |
+| peak size (mb)         | The size on entry of this GC (includes fragmentation) in MB.                                                                                                                     | `TraceGC.HeapSizePeakMB`                                                                  |
+| after size (mb)        | The size on exit of thi sGC (includes fragmentation) in MB.                                                                                                                      | `TraceGC.HeapSizeAfterMB`                                                                 |
+| peak/after             | Peak / After                                                                                                                                                                    | `TraceGC.HeapSizePeakMB / TraceGC.HeapSizeAfterMB`                                        |
+| promoted (mb)          | Memory this GC promoted in MB.                                                                                                                                                   | `TraceGC.PromotedMB`                                                                      |
+| gen0 size (mb)         | Size of gen0 at the end of this GC in MB.                                                                                                                                        | `TraceGC.GenSizeAfterMB(Gens.Gen0)`                                                       |
+| gen0 survival rate     | The % of objects in Gen0 that survived this GC.                                                                                                                                 | `TraceGC.SurvivalPercent(Gens.Gen0)`                                                      |
+| gen0 frag ratio        | The % of fragmentation on Gen0 at the end of this GC.                                                                                                                            | `TraceGC.GenFragmentationPercent(Gens.Gen0)`                                              |
+| gen1 size (mb)         | Size of gen1 at the end of this GC in MB.                                                                                                                                        | `TraceGC.GenSizeAfterMB(Gens.Gen1)`                                                       |
+| gen1 survival rate     | The % of objects in Gen1 that survived this GC. Only available if we are doing a gen1 GC.                                                                                       | `TraceGC.SurvivalPercent(Gens.Gen1)`                                                      |
+| gen1 frag ratio        | The % of fragmentation on Gen1 at the end of this GC.                                                                                                                            | `TraceGC.GenFragmentationPercent(Gens.Gen1)`                                              |
+| gen2 size (mb)         | Size of Gen2 in MB at the end of this GC.                                                                                                                                       | `TraceGC.GenSizeAfterMB(Gens.Gen2)`                                                       |
+| gen2 survival rate     | The % of objects in Gen2 that survived this GC. Only available if we are doing a gen2 GC.                                                                                       | `TraceGC.SurvivalPercent(Gens.Gen2)`                                                      |
+| gen2 frag ratio        | The % of fragmentation on Gen2 at the end of this GC.                                                                                                                            | `TraceGC.GenFragmentationPercent(Gens.Gen2)`                                              |
+| LOH size (mb)          | Size of Large object heap (LOH) at the end of this GC in MB.                                                                                                                     | `TraceGC.GenSizeAfterMB(Gens.LargeObj)`                                                   |
+| LOH survival rate      | The % of objects in the large object heap (LOH) that survived the GC. Only available if we are doing a gen2 GC.                                                                  | `TraceGC.SurvivalPercent(Gens.LargeObj)`                                                  |
+| LOH frag ratio         | The % of fragmentation on the large object heap (LOH) at the end of this GC.                                                                                                     | `TraceGC.GenFragmentationPercent(Gens.LargeObj)`                                          |
+| finalize promoted (mb) | The size of finalizable objects that were discovered to be dead and so promoted during this GC, in MB.                                                                           | `TraceGC.HeapStats.FinalizationPromotedSize / 1000000.0`                                  |
+| pinned objects         | Number of pinned objects observed in this GC.                                                                                                                                    | `TraceGC.HeapStats.PinnedObjectCount`                                                     |
 
 ## Adding New Columns
 
@@ -117,6 +108,14 @@ The process to add a new column from the ``TraceGC`` event is the following:
    4. Format (optional)
 3. Optionally add corresponding unit tests.
 4. Update the documentation here with the new column.
+
+## Unit Tests
+
+The unit tests are in the ``test`` directory and can be run by:
+
+```
+dotnet test
+```
 
 **Building**
 

--- a/src/windows/DefaultConfig.yaml
+++ b/src/windows/DefaultConfig.yaml
@@ -16,8 +16,9 @@ available_columns:
     - pause (ms)                          # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small.
     - reason                              # Reason for GC.
     - suspension time (ms)                # The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs.
-    - pause time % since last GC          # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small
-    - percent time in GC                  # Since the last GC, GC pause time expressed as a percentage of total process time. For background GC, this includes the pause time for foreground GCs that occur during the background GC.
+    - pause time % since last GC          # Since the last GC, GC pause time expressed as a percentage of total process time.  For background GC, this includes the pause time for foreground GCs that occur during the background GC.
+
+    - percent time in GC                  #  Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage.
     - amount allocated in gen 0           # Amount allocated since the last GC occurred.
     - gen0 allocation rate                # The average allocation rate since the last GC.
     - peak                                # The peak size of the GC during GC.

--- a/src/windows/DefaultConfig.yaml
+++ b/src/windows/DefaultConfig.yaml
@@ -5,9 +5,11 @@
     - gen
     - pause (ms)
     - reason
-    - gen0 size at end of this GC
-    - genlargeobj size at end of this GC
-    - finalize promoted for GC
+    - gen0 size (mb) 
+    - LOH size (mb) 
+    - peak/after
+    - CPU time (%)
+    - gen2 size (mb)
 
 available_columns:
     # all columns available to be displayed.
@@ -15,37 +17,31 @@ available_columns:
     - type                                # Type of GC.
     - pause (ms)                          # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small.
     - reason                              # Reason for GC.
-    - suspension time (ms)                # The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs.
-    - pause time % since last GC          # Since the last GC, GC pause time expressed as a percentage of total process time.  For background GC, this includes the pause time for foreground GCs that occur during the background GC.
-
-    - percent time in GC                  #  Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage.
-    - amount allocated in gen 0           # Amount allocated since the last GC occurred.
-    - gen0 allocation rate                # The average allocation rate since the last GC.
-    - peak                                # The peak size of the GC during GC.
-    - size at end of this GC              # The size after GC (includes fragmentation).
-    - ratio of peak/after                 # Peak / After.
-    - memory this gc promoted             # Memory this GC promoted.
-
+    - suspension time (ms)                # The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs. 
+    - pause time (%)                      # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small. 
+    - CPU time (%)                        # Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage. 
+    - gen0 alloc (mb)                     # Amount allocated in Gen0 since the last GC occurred in MB. 
+    - gen0 alloc rate                     # The average allocation rate since the last GC.
+    - peak size (mb)                      # The size on entry of this GC (includes fragmentation) in MB. 
+    - after size (mb)                     # The size on exit of this GC (includes fragmentation) in MB. 
+    - peak/after                          # Peak / After.
+    - promoted (mb)                       # Memory this GC promoted.
     # Gen0
-    - gen0 size at end of this GC         # Size of gen0 at the end of this GC.
+    - gen0 size (mb)                      # Size of gen0 at the end of this GC in MB. 
     - gen0 survival rate                  # The % of objects in Gen0 that survived this GC.
-    - gen0 frag ratio                     # The % of free space on gen0.
-
+    - gen0 frag ratio                     # The % of fragmentation on Gen0 at the end of this GC. 
     # Gen1
-    - gen1 size at end of this GC         # Size of gen1 at the end of this GC.
+    - gen1 size (mb)                      # Size of gen1 at the end of this GC in MB.
     - gen1 survival rate                  # The % of objects in Gen1 that survived this GC. Only available if we are doing a gen1 GC.
-    - gen1 frag ratio                     # The % of free space on Gen1 that is betweeen live objects.
-
+    - gen1 frag ratio                     # The % of fragmentation on Gen1 at the end of this GC. 
     # Gen 2
-    - gen2 size at end of this GC         # Size of Gen2 in MB at the end of this GC.
+    - gen2 size (mb)                      # Size of Gen2 at the end of this GC in MB.
     - gen2 survival rate                  # The % of objects in Gen2 that survived this GC. Only available if we are doing a gen2 GC.
-    - gen2 frag ratio                     # The % of free space on gen2.
-
+    - gen2 frag ratio                     # The % of fragmentation on Gen2 at the end of this GC. 
     # LOH
-    - genlargeobj size at end of this GC  # Size of Large object heap (LOH) in MB at the end of this GC.
-    - genlargeobj survival rate           # The % of objects in the large object heap (LOH) that survived the GC. Only available if we are doing a gen2 GC.
-    - genlargeobj frag ratio              # The % of free space that is between live objects on the large object heap (LOH).
-
+    - LOH size (mb)                       # Size of Large object heap (LOH) at the end of this GC in MB. 
+    - LOH survival rate                   # The % of objects in the large object heap (LOH) that survived the GC. Only available if we are doing a gen2 GC. 
+    - LOH frag ratio                      # The % of fragmentation on the large object heap (LOH) at the end of this GC. 
     # Finalized and Pinned
-    - finalize promoted for GC            # The number of MB of objects that have finalizers (destructors) that survived this GC.
-    - no. of pinned objects for GC        # Number of pinned objects this GC promoted.
+    - finalize promoted (mb)              # The size of finalizable objects that were discovered to be dead and so promoted during this GC, in MB. 
+    - pinned objects                      # Number of pinned objects this GC promoted.

--- a/src/windows/DefaultConfig.yaml
+++ b/src/windows/DefaultConfig.yaml
@@ -1,13 +1,50 @@
 ﻿columns:
     # optional columns to add. The default one is always: `index` or GC#.
+    # to add a column, add it from the ``available_columns`` section.
     - type
     - gen
     - pause (ms)
     - reason
+    - gen0 size at end of this GC
+    - genlargeobj size at end of this GC
+    - finalize promoted for GC
 
 available_columns:
-    # all columns available - could be many here since TraceGC exposes lots of stuff
-    - gen        # Number of Generation
-    - type       # Type of GC
-    - pause (ms) # GC Pause Time in MSec  
-    - reason     # GC Reason
+    # all columns available to be displayed.
+    - gen                                 # The Generation.
+    - type                                # Type of GC.
+    - pause (ms)                          # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small.
+    - reason                              # Reason for GC.
+    - suspension time (ms)                # The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs.
+    - pause time % since last GC          # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small
+    - percent time in GC                  # Since the last GC, GC pause time expressed as a percentage of total process time. For background GC, this includes the pause time for foreground GCs that occur during the background GC.
+    - amount allocated in gen 0           # Amount allocated since the last GC occurred.
+    - gen0 allocation rate                # The average allocation rate since the last GC.
+    - peak                                # The peak size of the GC during GC.
+    - size at end of this GC              # The size after GC (includes fragmentation).
+    - ratio of peak/after                 # Peak / After.
+    - memory this gc promoted             # Memory this GC promoted.
+
+    # Gen0
+    - gen0 size at end of this GC         # Size of gen0 at the end of this GC.
+    - gen0 survival rate                  # The % of objects in Gen0 that survived this GC.
+    - gen0 frag ratio                     # The % of free space on gen0.
+
+    # Gen1
+    - gen1 size at end of this GC         # Size of gen1 at the end of this GC.
+    - gen1 survival rate                  # The % of objects in Gen1 that survived this GC. Only available if we are doing a gen1 GC.
+    - gen1 frag ratio                     # The % of free space on Gen1 that is betweeen live objects.
+
+    # Gen 2
+    - gen2 size at end of this GC         # Size of Gen2 in MB at the end of this GC.
+    - gen2 survival rate                  # The % of objects in Gen2 that survived this GC. Only available if we are doing a gen2 GC.
+    - gen2 frag ratio                     # The % of free space on gen2.
+
+    # LOH
+    - genlargeobj size at end of this GC  # Size of Large object heap (LOH) in MB at the end of this GC.
+    - genlargeobj survival rate           # The % of objects in the large object heap (LOH) that survived the GC. Only available if we are doing a gen2 GC.
+    - genlargeobj frag ratio              # The % of free space that is between live objects on the large object heap (LOH).
+
+    # Finalized and Pinned
+    - finalize promoted for GC            # The number of MB of objects that have finalizers (destructors) that survived this GC.
+    - no. of pinned objects for GC        # Number of pinned objects this GC promoted.

--- a/src/windows/Utilities/ColumnInfo.cs
+++ b/src/windows/Utilities/ColumnInfo.cs
@@ -8,10 +8,14 @@ namespace realmon.Utilities
     /// </summary>
     internal sealed class ColumnInfo
     {
-        public ColumnInfo(string name, int alignment, Func<TraceGC, object> getColumnValueFromEvent, string format = "")
+        public ColumnInfo(string name,
+                          Func<TraceGC, object> getColumnValueFromEvent,
+                          int? alignment = null,
+                          string format = "")
         {
             Name = name;
-            Alignment = alignment;
+            // If no alignment is specified, default to the length of the name.
+            Alignment = alignment ?? Name.Length;
             GetColumnValueFromEvent = getColumnValueFromEvent;
             Format = format;
         }

--- a/src/windows/Utilities/ColumnInfoMap.cs
+++ b/src/windows/Utilities/ColumnInfoMap.cs
@@ -19,9 +19,9 @@ namespace realmon.Utilities
         /// <param name="generation"></param>
         internal static void AddGenerateBasedColumns(Gens generation)
         {
-            string gen = generation.ToString().ToLower();
-            Map[$"{gen} size at end of this GC"] =
-                new ColumnInfo(name: $"{gen.ToString().ToLower()} size at end of this GC",
+            string gen = generation != Gens.GenLargeObj ? generation.ToString().ToLower() : "LOH";
+            Map[$"{gen} size (mb)"] =
+                new ColumnInfo(name: $"{gen.ToString().ToLower()} size (mb)",
                                format: "N3",
                                getColumnValueFromEvent: (traceEvent) => traceEvent.GenSizeAfterMB(generation));
             Map[$"{gen} survival rate"] =
@@ -64,41 +64,41 @@ namespace realmon.Utilities
                                                          format: "N3",
                                                          getColumnValueFromEvent: (traceEvent) => traceEvent.SuspendDurationMSec )},
 
-                { "pause time % since last GC", new ColumnInfo(name: "pause time % since last GC",
-                                                               format: "N1",
-                                                               getColumnValueFromEvent: (traceEvent) => traceEvent.PauseTimePercentageSinceLastGC )},
+                { "pause time (%)", new ColumnInfo(name: "pause time (%)", 
+                                                   format: "N1",
+                                                   getColumnValueFromEvent: (traceEvent) => traceEvent.PauseTimePercentageSinceLastGC )},
 
-                { "percent time in GC", new ColumnInfo(name: "percent time in GC",
-                                                    format: "N1",
-                                                    getColumnValueFromEvent: (traceEvent) => traceEvent.PercentTimeInGC )},
+                { "CPU time (%)", new ColumnInfo(name: "CPU time (%)",
+                                                 format: "N1",
+                                                 getColumnValueFromEvent: (traceEvent) => traceEvent.PercentTimeInGC )},
 
-                { "amount allocated in gen 0", new ColumnInfo(name: "amount allocated in gen 0",
-                                                              format: "N3",
-                                                              getColumnValueFromEvent: (traceEvent) => traceEvent.UserAllocated[(int)Gens.Gen0] )},
-                { "gen0 allocation rate", new ColumnInfo(name: "gen0 allocation rate",
-                                                              format: "N2",
-                                                              getColumnValueFromEvent: (traceEvent) =>
-                                                              {
-                                                                  return (traceEvent.UserAllocated[(int)Gens.Gen0] * 1000.0) / traceEvent.DurationSinceLastRestartMSec;
-                                                              })},
-                { "peak", new ColumnInfo(name: "peak",
-                                         format: "N3",
-                                         getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizePeakMB)},
-                { "size at end of this GC", new ColumnInfo(name: "size at end of this GC",
-                                                           format: "N3",
-                                                           getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizeAfterMB )},
-                { "ratio of peak/after", new ColumnInfo(name: "ratio of peak/after",
+                { "gen0 alloc (mb)", new ColumnInfo(name: "gen0 alloc (mb)",
+                                                    format: "N3",
+                                                    getColumnValueFromEvent: (traceEvent) => traceEvent.UserAllocated[(int)Gens.Gen0] )},
+                { "gen0 alloc rate", new ColumnInfo(name: "gen0 alloc rate",
+                                                    format: "N2",
+                                                    getColumnValueFromEvent: (traceEvent) =>
+                                                    {
+                                                        return (traceEvent.UserAllocated[(int)Gens.Gen0] * 1000.0) / traceEvent.DurationSinceLastRestartMSec;
+                                                    })},
+                { "peak size (mb)", new ColumnInfo(name: "peak size (mb)",
+                                                   format: "N3",
+                                                   getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizePeakMB)},
+                { "after size (mb)", new ColumnInfo(name: "after size (mb)",
+                                                    format: "N3",
+                                                    getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizeAfterMB )},
+                { "peak/after", new ColumnInfo(name: "peak/after",
+                                               format: "N2",
+                                               getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizePeakMB / traceEvent.HeapSizeAfterMB )},
+                { "promoted (mb)", new ColumnInfo(name: "promoted (mb)",
+                                                  format: "N3",
+                                                  getColumnValueFromEvent: (traceEvent) => traceEvent.PromotedMB )},
+                { "finalize promoted (mb)", new ColumnInfo(name: "finalize promoted (mb)",
                                                            format: "N2",
-                                                           getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizePeakMB / traceEvent.HeapSizePeakMB )},
-                { "memory this gc promoted", new ColumnInfo(name: "memory this gc promoted",
-                                                           format: "N3",
-                                                           getColumnValueFromEvent: (traceEvent) => traceEvent.PromotedMB )},
-                { "finalize promoted for GC", new ColumnInfo(name: "finalize promoted for this GC",
-                                                                  format: "N2",
-                                                                  getColumnValueFromEvent: (traceEvent) => traceEvent.HeapStats.FinalizationPromotedSize / 1000000.0 )},
-                { "no. of pinned objects for GC", new ColumnInfo(name: "no. of pinned objects for GC",
-                                                                  format: "N0",
-                                                                  getColumnValueFromEvent: (traceEvent) => traceEvent.HeapStats.PinnedObjectCount )},
+                                                           getColumnValueFromEvent: (traceEvent) => traceEvent.HeapStats.FinalizationPromotedSize / 1000000.0 )},
+                { "pinned objects", new ColumnInfo(name: "pinned objects",
+                                                   format: "N0",
+                                                   getColumnValueFromEvent: (traceEvent) => traceEvent.HeapStats.PinnedObjectCount )},
             };
     }
 }

--- a/src/windows/Utilities/ColumnInfoMap.cs
+++ b/src/windows/Utilities/ColumnInfoMap.cs
@@ -1,9 +1,39 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using System.Collections.Generic;
 
 namespace realmon.Utilities
 {
     internal static class ColumnInfoMap
     {
+        static ColumnInfoMap()
+        {
+            AddGenerateBasedColumns(Gens.Gen0);
+            AddGenerateBasedColumns(Gens.Gen1);
+            AddGenerateBasedColumns(Gens.Gen2);
+            AddGenerateBasedColumns(Gens.GenLargeObj);
+        }
+
+        /// <summary>
+        /// Generates the generation size at the end of the GC, this generation's survival rate and this generation's frag ratio.
+        /// </summary>
+        /// <param name="generation"></param>
+        internal static void AddGenerateBasedColumns(Gens generation)
+        {
+            string gen = generation.ToString().ToLower();
+            Map[$"{gen} size at end of this GC"] =
+                new ColumnInfo(name: $"{gen.ToString().ToLower()} size at end of this GC",
+                               format: "N3",
+                               getColumnValueFromEvent: (traceEvent) => traceEvent.GenSizeAfterMB(generation));
+            Map[$"{gen} survival rate"] =
+                new ColumnInfo(name: $"{gen.ToString().ToLower()} survival rate",
+                               format: "N0",
+                               getColumnValueFromEvent: (traceEvent) => traceEvent.SurvivalPercent(generation));
+            Map[$"{gen} frag ratio"] =
+                new ColumnInfo(name: $"{gen.ToString().ToLower()} frag ratio",
+                               format: "N0",
+                               getColumnValueFromEvent: (traceEvent) => traceEvent.GenFragmentationPercent(generation));
+        }
+
         /// <summary>
         /// Map that is a registry of the available columns.
         /// </summary>
@@ -22,13 +52,53 @@ namespace realmon.Utilities
                 { "gen", new ColumnInfo(name: "gen",
                                         alignment: 5,
                                         getColumnValueFromEvent: (traceEvent) => traceEvent.Generation )},
-                { "pause (ms)", new ColumnInfo(name: "pause (ms)", 
-                                               format: "N2", 
+                { "pause (ms)", new ColumnInfo(name: "pause (ms)",
+                                               format: "N2",
                                                alignment: 10,
                                                getColumnValueFromEvent: (traceEvent) => traceEvent.PauseDurationMSec )},
-                { "reason", new ColumnInfo(name: "reason", 
+                { "reason", new ColumnInfo(name: "reason",
                                            alignment: 21,
                                            getColumnValueFromEvent: (traceEvent) => traceEvent.Reason )},
+
+                { "suspension time (ms)", new ColumnInfo(name: "suspension time (ms)",
+                                                         format: "N3",
+                                                         getColumnValueFromEvent: (traceEvent) => traceEvent.SuspendDurationMSec )},
+
+                { "pause time % since last GC", new ColumnInfo(name: "pause time % since last GC",
+                                                               format: "N1",
+                                                               getColumnValueFromEvent: (traceEvent) => traceEvent.PauseTimePercentageSinceLastGC )},
+
+                { "percent time in GC", new ColumnInfo(name: "percent time in GC",
+                                                    format: "N1",
+                                                    getColumnValueFromEvent: (traceEvent) => traceEvent.PercentTimeInGC )},
+
+                { "amount allocated in gen 0", new ColumnInfo(name: "amount allocated in gen 0",
+                                                              format: "N3",
+                                                              getColumnValueFromEvent: (traceEvent) => traceEvent.UserAllocated[(int)Gens.Gen0] )},
+                { "gen0 allocation rate", new ColumnInfo(name: "gen0 allocation rate",
+                                                              format: "N2",
+                                                              getColumnValueFromEvent: (traceEvent) =>
+                                                              {
+                                                                  return (traceEvent.UserAllocated[(int)Gens.Gen0] * 1000.0) / traceEvent.DurationSinceLastRestartMSec;
+                                                              })},
+                { "peak", new ColumnInfo(name: "peak",
+                                         format: "N3",
+                                         getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizePeakMB)},
+                { "size at end of this GC", new ColumnInfo(name: "size at end of this GC",
+                                                           format: "N3",
+                                                           getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizeAfterMB )},
+                { "ratio of peak/after", new ColumnInfo(name: "ratio of peak/after",
+                                                           format: "N2",
+                                                           getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizePeakMB / traceEvent.HeapSizePeakMB )},
+                { "memory this gc promoted", new ColumnInfo(name: "memory this gc promoted",
+                                                           format: "N3",
+                                                           getColumnValueFromEvent: (traceEvent) => traceEvent.PromotedMB )},
+                { "finalize promoted for GC", new ColumnInfo(name: "finalize promoted for this GC",
+                                                                  format: "N2",
+                                                                  getColumnValueFromEvent: (traceEvent) => traceEvent.HeapStats.FinalizationPromotedSize / 1000000.0 )},
+                { "no. of pinned objects for GC", new ColumnInfo(name: "no. of pinned objects for GC",
+                                                                  format: "N0",
+                                                                  getColumnValueFromEvent: (traceEvent) => traceEvent.HeapStats.PinnedObjectCount )},
             };
     }
 }

--- a/tests/GCRealTimeMon.UnitTests/ConfigurationReader/TestConfigurations/Default.yaml
+++ b/tests/GCRealTimeMon.UnitTests/ConfigurationReader/TestConfigurations/Default.yaml
@@ -16,8 +16,9 @@ available_columns:
     - pause (ms)                          # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small.
     - reason                              # Reason for GC.
     - suspension time (ms)                # The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs.
-    - pause time % since last GC          # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small
-    - percent time in GC                  # Since the last GC, GC pause time expressed as a percentage of total process time. For background GC, this includes the pause time for foreground GCs that occur during the background GC.
+    - pause time % since last GC          # Since the last GC, GC pause time expressed as a percentage of total process time.  For background GC, this includes the pause time for foreground GCs that occur during the background GC.
+
+    - percent time in GC                  #  Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage.
     - amount allocated in gen 0           # Amount allocated since the last GC occurred.
     - gen0 allocation rate                # The average allocation rate since the last GC.
     - peak                                # The peak size of the GC during GC.

--- a/tests/GCRealTimeMon.UnitTests/ConfigurationReader/TestConfigurations/Default.yaml
+++ b/tests/GCRealTimeMon.UnitTests/ConfigurationReader/TestConfigurations/Default.yaml
@@ -5,9 +5,9 @@
     - gen
     - pause (ms)
     - reason
-    - gen0 size at end of this GC
-    - genlargeobj size at end of this GC
-    - finalize promoted for GC
+    - gen0 size (mb) 
+    - LOH size (mb) 
+    - finalize promoted (mb) 
 
 available_columns:
     # all columns available to be displayed.
@@ -15,37 +15,31 @@ available_columns:
     - type                                # Type of GC.
     - pause (ms)                          # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small.
     - reason                              # Reason for GC.
-    - suspension time (ms)                # The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs.
-    - pause time % since last GC          # Since the last GC, GC pause time expressed as a percentage of total process time.  For background GC, this includes the pause time for foreground GCs that occur during the background GC.
-
-    - percent time in GC                  #  Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage.
-    - amount allocated in gen 0           # Amount allocated since the last GC occurred.
-    - gen0 allocation rate                # The average allocation rate since the last GC.
-    - peak                                # The peak size of the GC during GC.
-    - size at end of this GC              # The size after GC (includes fragmentation).
-    - ratio of peak/after                 # Peak / After.
-    - memory this gc promoted             # Memory this GC promoted.
-
+    - suspension time (ms)                # The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs. 
+    - pause time (%)                      # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small. 
+    - CPU time (%)                        # Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage. 
+    - gen0 alloc (mb)                     # Amount allocated in Gen0 since the last GC occurred in MB. 
+    - gen0 alloc rate                     # The average allocation rate since the last GC.
+    - peak size (mb)                      # The size on entry of this GC (includes fragmentation) in MB. 
+    - after size (mb)                     # The size on exit of this GC (includes fragmentation) in MB. 
+    - peak/after                          # Peak / After.
+    - promoted (mb)                       # Memory this GC promoted.
     # Gen0
-    - gen0 size at end of this GC         # Size of gen0 at the end of this GC.
+    - gen0 size (mb)                      # Size of gen0 at the end of this GC in MB. 
     - gen0 survival rate                  # The % of objects in Gen0 that survived this GC.
-    - gen0 frag ratio                     # The % of free space on gen0.
-
+    - gen0 frag ratio                     # The % of fragmentation on Gen0 at the end of this GC. 
     # Gen1
-    - gen1 size at end of this GC         # Size of gen1 at the end of this GC.
+    - gen1 size (mb)                      # Size of gen1 at the end of this GC in MB.
     - gen1 survival rate                  # The % of objects in Gen1 that survived this GC. Only available if we are doing a gen1 GC.
-    - gen1 frag ratio                     # The % of free space on Gen1 that is betweeen live objects.
-
+    - gen1 frag ratio                     # The % of fragmentation on Gen1 at the end of this GC. 
     # Gen 2
-    - gen2 size at end of this GC         # Size of Gen2 in MB at the end of this GC.
+    - gen2 size (mb)                      # Size of Gen2 at the end of this GC in MB.
     - gen2 survival rate                  # The % of objects in Gen2 that survived this GC. Only available if we are doing a gen2 GC.
-    - gen2 frag ratio                     # The % of free space on gen2.
-
+    - gen2 frag ratio                     # The % of fragmentation on Gen2 at the end of this GC. 
     # LOH
-    - genlargeobj size at end of this GC  # Size of Large object heap (LOH) in MB at the end of this GC.
-    - genlargeobj survival rate           # The % of objects in the large object heap (LOH) that survived the GC. Only available if we are doing a gen2 GC.
-    - genlargeobj frag ratio              # The % of free space that is between live objects on the large object heap (LOH).
-
+    - LOH size (mb)                       # Size of Large object heap (LOH) at the end of this GC in MB. 
+    - LOH survival rate                   # The % of objects in the large object heap (LOH) that survived the GC. Only available if we are doing a gen2 GC. 
+    - LOH frag ratio                      # The % of fragmentation on the large object heap (LOH) at the end of this GC. 
     # Finalized and Pinned
-    - finalize promoted for GC            # The number of MB of objects that have finalizers (destructors) that survived this GC.
-    - no. of pinned objects for GC        # Number of pinned objects this GC promoted.
+    - finalize promoted (mb)              # The size of finalizable objects that were discovered to be dead and so promoted during this GC, in MB. 
+    - pinned objects                      # Number of pinned objects this GC promoted.

--- a/tests/GCRealTimeMon.UnitTests/ConfigurationReader/TestConfigurations/Default.yaml
+++ b/tests/GCRealTimeMon.UnitTests/ConfigurationReader/TestConfigurations/Default.yaml
@@ -1,13 +1,50 @@
 ﻿columns:
     # optional columns to add. The default one is always: `index` or GC#.
+    # to add a column, add it from the ``available_columns`` section.
     - type
-    - gen 
+    - gen
     - pause (ms)
     - reason
+    - gen0 size at end of this GC
+    - genlargeobj size at end of this GC
+    - finalize promoted for GC
 
 available_columns:
-    # all columns available - could be many here since TraceGC exposes lots of stuff
-    - gen
-    - type
-    - pause (ms)
-    - reason
+    # all columns available to be displayed.
+    - gen                                 # The Generation.
+    - type                                # Type of GC.
+    - pause (ms)                          # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small.
+    - reason                              # Reason for GC.
+    - suspension time (ms)                # The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs.
+    - pause time % since last GC          # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small
+    - percent time in GC                  # Since the last GC, GC pause time expressed as a percentage of total process time. For background GC, this includes the pause time for foreground GCs that occur during the background GC.
+    - amount allocated in gen 0           # Amount allocated since the last GC occurred.
+    - gen0 allocation rate                # The average allocation rate since the last GC.
+    - peak                                # The peak size of the GC during GC.
+    - size at end of this GC              # The size after GC (includes fragmentation).
+    - ratio of peak/after                 # Peak / After.
+    - memory this gc promoted             # Memory this GC promoted.
+
+    # Gen0
+    - gen0 size at end of this GC         # Size of gen0 at the end of this GC.
+    - gen0 survival rate                  # The % of objects in Gen0 that survived this GC.
+    - gen0 frag ratio                     # The % of free space on gen0.
+
+    # Gen1
+    - gen1 size at end of this GC         # Size of gen1 at the end of this GC.
+    - gen1 survival rate                  # The % of objects in Gen1 that survived this GC. Only available if we are doing a gen1 GC.
+    - gen1 frag ratio                     # The % of free space on Gen1 that is betweeen live objects.
+
+    # Gen 2
+    - gen2 size at end of this GC         # Size of Gen2 in MB at the end of this GC.
+    - gen2 survival rate                  # The % of objects in Gen2 that survived this GC. Only available if we are doing a gen2 GC.
+    - gen2 frag ratio                     # The % of free space on gen2.
+
+    # LOH
+    - genlargeobj size at end of this GC  # Size of Large object heap (LOH) in MB at the end of this GC.
+    - genlargeobj survival rate           # The % of objects in the large object heap (LOH) that survived the GC. Only available if we are doing a gen2 GC.
+    - genlargeobj frag ratio              # The % of free space that is between live objects on the large object heap (LOH).
+
+    # Finalized and Pinned
+    - finalize promoted for GC            # The number of MB of objects that have finalizers (destructors) that survived this GC.
+    - no. of pinned objects for GC        # Number of pinned objects this GC promoted.

--- a/tests/GCRealTimeMon.UnitTests/GCRealTimeMon.UnitTests.csproj
+++ b/tests/GCRealTimeMon.UnitTests/GCRealTimeMon.UnitTests.csproj
@@ -21,6 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="ConfigurationReader\TestConfigurations\Default.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="ConfigurationReader\TestConfigurations\NoAvailableColumns.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -31,9 +34,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="ConfigurationReader\TestConfigurations\NoColumns.yaml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="ConfigurationReader\TestConfigurations\Default.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Added the columns below from [here](https://github.com/microsoft/perfview/blob/main/src/PerfView/GcStats.cs#L723) along with documentation. Updated the documentation accordingly from the Perf View based descriptions.

| Column Name            | Full Name / Description                                                                                                                                                         | Trace Event Property                                                                      |
| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| index | The GC Index. | ``TraceGC.Number``
| gen | The Generation. | ``TraceGC.Generation``
| type | The Type of GC. | ``TraceGC.Type``
| reason | Reason for GC. | ``TraceGC.Reason``
| suspension time (ms)   | The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs. | `TraceGC.SuspendDurationMSec`                                                             |
| pause time (%)           | The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small.                                   | `TraceGC.PauseTimePercentageSinceLastGC`                                                  |
| CPU time (%)             | Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage.                                                                              | `TraceGC.PercentTimeInGC`                                                                 |
| gen0 alloc (mb)        | Amount allocated in Gen0 since the last GC occurred in MB.                                                                                                                       | `TraceGC.UserAllocated[(int)Gens.Gen0]`                                                   |
| gen0 alloc rate        | The average allocation rate since the last GC.                                                                                                                                   | `(TraceGC.UserAllocated[(int)Gens.Gen0] * 1000.0) / TraceGC.DurationSinceLastRestartMSec` |
| peak size (mb)         | The size on entry of this GC (includes fragmentation) in MB.                                                                                                                     | `TraceGC.HeapSizePeakMB`                                                                  |
| after size (mb)        | The size on exit of thi sGC (includes fragmentation) in MB.                                                                                                                      | `TraceGC.HeapSizeAfterMB`                                                                 |
| peak/after             | Peak / After                                                                                                                                                                    | `TraceGC.HeapSizePeakMB / TraceGC.HeapSizeAfterMB`                                        |
| promoted (mb)          | Memory this GC promoted in MB.                                                                                                                                                   | `TraceGC.PromotedMB`                                                                      |
| gen0 size (mb)         | Size of gen0 at the end of this GC in MB.                                                                                                                                        | `TraceGC.GenSizeAfterMB(Gens.Gen0)`                                                       |
| gen0 survival rate     | The % of objects in Gen0 that survived this GC.                                                                                                                                 | `TraceGC.SurvivalPercent(Gens.Gen0)`                                                      |
| gen0 frag ratio        | The % of fragmentation on Gen0 at the end of this GC.                                                                                                                            | `TraceGC.GenFragmentationPercent(Gens.Gen0)`                                              |
| gen1 size (mb)         | Size of gen1 at the end of this GC in MB.                                                                                                                                        | `TraceGC.GenSizeAfterMB(Gens.Gen1)`                                                       |
| gen1 survival rate     | The % of objects in Gen1 that survived this GC. Only available if we are doing a gen1 GC.                                                                                       | `TraceGC.SurvivalPercent(Gens.Gen1)`                                                      |
| gen1 frag ratio        | The % of fragmentation on Gen1 at the end of this GC.                                                                                                                            | `TraceGC.GenFragmentationPercent(Gens.Gen1)`                                              |
| gen2 size (mb)         | Size of Gen2 in MB at the end of this GC.                                                                                                                                       | `TraceGC.GenSizeAfterMB(Gens.Gen2)`                                                       |
| gen2 survival rate     | The % of objects in Gen2 that survived this GC. Only available if we are doing a gen2 GC.                                                                                       | `TraceGC.SurvivalPercent(Gens.Gen2)`                                                      |
| gen2 frag ratio        | The % of fragmentation on Gen2 at the end of this GC.                                                                                                                            | `TraceGC.GenFragmentationPercent(Gens.Gen2)`                                              |
| LOH size (mb)          | Size of Large object heap (LOH) at the end of this GC in MB.                                                                                                                     | `TraceGC.GenSizeAfterMB(Gens.LargeObj)`                                                   |
| LOH survival rate      | The % of objects in the large object heap (LOH) that survived the GC. Only available if we are doing a gen2 GC.                                                                  | `TraceGC.SurvivalPercent(Gens.LargeObj)`                                                  |
| LOH frag ratio         | The % of fragmentation on the large object heap (LOH) at the end of this GC.                                                                                                     | `TraceGC.GenFragmentationPercent(Gens.LargeObj)`                                          |
| finalize promoted (mb) | The size of finalizable objects that were discovered to be dead and so promoted during this GC, in MB.                                                                           | `TraceGC.HeapStats.FinalizationPromotedSize / 1000000.0`                                  |
| pinned objects         | Number of pinned objects observed in this GC.                                                                                                                                    | `TraceGC.HeapStats.PinnedObjectCount`                                                     |

Example of adding some columns:
![image](https://user-images.githubusercontent.com/4951960/141067525-b9ab3d52-4931-4d51-b6e8-821408f386ad.png)

```
columns:
    # optional columns to add. The default one is always: `index` or GC#.
    # to add a column, add it from the ``available_columns`` section.
    - type
    - gen
    - pause (ms)
    - reason
    - gen0 size (mb) 
    - LOH size (mb) 
```