### PR TITLE
Added the optional stats_mode configuration for printing heap stats on a timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Heap Stats as of 2021-11-08 03:15:30Z (Run 1 for gen 0):
 The configuration file is a YAML based file currently with the following sections:
 - __columns__: The columns to display. 
 - __available_columns__: All columns that are available to display.
+- __stats_mode__: Configurations related to the heap stats. 
+  - ``timer``: Specifying this with a period magnitude and type that dictates the candence of the timer that prints the heap stats.
+    - the period type can either be in minutes 'm' or seconds 's'.
+    - the period magnitude has to be as an int.
+    - Examples: 
+      - ``"timer" : "5m"  # 5 minutes``
+      - ``"timer" : "20s" # 20 seconds``
+  - A full example with the Heap printing every 30 seconds can be found [here](tests/GCRealTimeMon.UnitTests/ConfigurationReader/TestConfigurations/DefaultWithStatsMode.yaml)
 
 Currently, the available columns are:
 

--- a/src/Configuration/Configuration.cs
+++ b/src/Configuration/Configuration.cs
@@ -16,5 +16,10 @@ namespace realmon.Configuration
         /// All columns available to display. 
         /// </summary>
         public List<string> AvailableColumns { get; set; }
+
+        /// <summary>
+        /// Stats mode properties. 
+        /// </summary>
+        public Dictionary<string, string> StatsMode { get; set; }
     }
 }

--- a/src/Configuration/ConfigurationReader.cs
+++ b/src/Configuration/ConfigurationReader.cs
@@ -75,6 +75,32 @@ namespace realmon.Configuration
                     throw new KeyNotFoundException($"Column: {column} in the `available_column` list isn't a registered column in the ColumnInfoMap.");
                 }
             }
+
+            // Checks for the optional stats mode.
+            if (configuration.StatsMode != null)
+            {
+                // timer is a mandatory property if `stats_mode` is opted in.
+                if (!configuration.StatsMode.TryGetValue("timer", out string timer))
+                {
+                    throw new ArgumentException("`timer` is null.");
+                }
+
+                // timer format is #m or #s where # is the magnitude of the period and m is for minutes / s for seconds.
+                if (timer.Length <= 1)
+                {
+                    throw new ArgumentException("The `timer` value should be specified as a period as an int and a char representing the magnitude and the period type with minutes 'm' or seconds 's', respectively.");
+                }
+
+                if (timer[timer.Length - 1] != 's' && timer[timer.Length - 1] != 'm')
+                {
+                    throw new ArgumentException("The `timer` value should either end with a period type representing character - minutes 'm' or seconds 's'"); 
+                }
+
+                if (!int.TryParse(timer[0..^1], out int _))
+                {
+                    throw new ArgumentException("The `timer` value should be a number as the period magnitude followed by a period type representing character"); 
+                }
+            }
         }
     }
 }

--- a/src/DefaultConfig.yaml
+++ b/src/DefaultConfig.yaml
@@ -8,6 +8,7 @@
     - gen0 size (mb) 
     - LOH size (mb) 
     - peak/after
+    - CPU time (%)
     - gen2 size (mb)
 
 available_columns:
@@ -18,6 +19,7 @@ available_columns:
     - reason                              # Reason for GC.
     - suspension time (ms)                # The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs. 
     - pause time (%)                      # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small. 
+    - CPU time (%)                        # Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage. 
     - gen0 alloc (mb)                     # Amount allocated in Gen0 since the last GC occurred in MB. 
     - gen0 alloc rate                     # The average allocation rate since the last GC.
     - peak size (mb)                      # The size on entry of this GC (includes fragmentation) in MB. 

--- a/src/DefaultConfig.yaml
+++ b/src/DefaultConfig.yaml
@@ -8,7 +8,6 @@
     - gen0 size (mb) 
     - LOH size (mb) 
     - peak/after
-    - CPU time (%)
     - gen2 size (mb)
 
 available_columns:
@@ -19,7 +18,6 @@ available_columns:
     - reason                              # Reason for GC.
     - suspension time (ms)                # The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs. 
     - pause time (%)                      # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small. 
-    - CPU time (%)                        # Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage. 
     - gen0 alloc (mb)                     # Amount allocated in Gen0 since the last GC occurred in MB. 
     - gen0 alloc rate                     # The average allocation rate since the last GC.
     - peak size (mb)                      # The size on entry of this GC (includes fragmentation) in MB. 

--- a/src/Utilities/PrintUtilities.cs
+++ b/src/Utilities/PrintUtilities.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Diagnostics.Tracing.Analysis.GC;
 using System;
-using System.Linq;
 using System.Text;
 
 namespace realmon.Utilities
@@ -47,7 +46,14 @@ namespace realmon.Utilities
                     repeatCount += columnInfo.Alignment + 3; // +3 is for the | and the enclosing space.
                 }
             }
-            return string.Concat(Enumerable.Repeat("-", repeatCount));
+
+            string lineSeparator = "";
+            for(int i = 0; i < repeatCount; i++)
+            {
+                lineSeparator = string.Concat(lineSeparator, "-");
+            }
+
+            return lineSeparator;
         }
 
         /// <summary>

--- a/tests/GCRealTimeMon.UnitTests/ConfigurationReader/ReadConfigurationAsync.cs
+++ b/tests/GCRealTimeMon.UnitTests/ConfigurationReader/ReadConfigurationAsync.cs
@@ -4,7 +4,6 @@ using realmon.Configuration;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace realmon.UnitTests
@@ -62,7 +61,7 @@ namespace realmon.UnitTests
             configuration.StatsMode.Should().ContainKeys("timer");
             configuration.StatsMode["timer"].Should().NotBeNull();
             int.TryParse(configuration.StatsMode["timer"][0..^1], out var _).Should().BeTrue();
-            bool conditionForPeriodType = configuration.StatsMode["timer"].Last() == 'm' || configuration.StatsMode["timer"].Last() == 's';
+            bool conditionForPeriodType = configuration.StatsMode["timer"][^1] == 'm' || configuration.StatsMode["timer"][^1] == 's';
             conditionForPeriodType.Should().BeTrue();
         }
 

--- a/tests/GCRealTimeMon.UnitTests/ConfigurationReader/ReadConfigurationAsync.cs
+++ b/tests/GCRealTimeMon.UnitTests/ConfigurationReader/ReadConfigurationAsync.cs
@@ -4,6 +4,7 @@ using realmon.Configuration;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace realmon.UnitTests
@@ -33,6 +34,36 @@ namespace realmon.UnitTests
             configuration.AvailableColumns.Should().Contain("gen");
             configuration.AvailableColumns.Should().Contain("pause (ms)");
             configuration.AvailableColumns.Should().Contain("reason");
+        }
+
+        [TestMethod]
+        public async Task ReadConfigurationAsync_ReadDefaultWithStatsMode_SuccessfullyParsed()
+        {
+            string defaultPath = Path.Combine(TestConfigurationPath, "DefaultWithStatsMode.yaml");
+            Configuration.Configuration configuration = await ConfigurationReader.ReadConfigurationAsync(defaultPath);
+            configuration.Should().NotBeNull();
+
+            // Check Columns.
+            configuration.Columns.Should().NotBeNull();
+            configuration.Columns.Should().Contain("type");
+            configuration.Columns.Should().Contain("gen");
+            configuration.Columns.Should().Contain("pause (ms)");
+            configuration.Columns.Should().Contain("reason");
+
+            // Check Available Columns.
+            configuration.AvailableColumns.Should().NotBeNull();
+            configuration.AvailableColumns.Should().Contain("type");
+            configuration.AvailableColumns.Should().Contain("gen");
+            configuration.AvailableColumns.Should().Contain("pause (ms)");
+            configuration.AvailableColumns.Should().Contain("reason");
+
+            // Check Stats Mode.
+            configuration.StatsMode.Should().NotBeNull();
+            configuration.StatsMode.Should().ContainKeys("timer");
+            configuration.StatsMode["timer"].Should().NotBeNull();
+            int.TryParse(configuration.StatsMode["timer"][0..^1], out var _).Should().BeTrue();
+            bool conditionForPeriodType = configuration.StatsMode["timer"].Last() == 'm' || configuration.StatsMode["timer"].Last() == 's';
+            conditionForPeriodType.Should().BeTrue();
         }
 
         [TestMethod]

--- a/tests/GCRealTimeMon.UnitTests/ConfigurationReader/TestConfigurations/DefaultWithStatsMode.yaml
+++ b/tests/GCRealTimeMon.UnitTests/ConfigurationReader/TestConfigurations/DefaultWithStatsMode.yaml
@@ -1,0 +1,49 @@
+﻿columns:
+    # optional columns to add. The default one is always: `index` or GC#.
+    # to add a column, add it from the ``available_columns`` section.
+    - type
+    - gen
+    - pause (ms)
+    - reason
+    - gen0 size (mb) 
+    - LOH size (mb) 
+    - finalize promoted (mb) 
+
+stats_mode:
+    # Print the heap stats on a timer with m: minutes; s: seconds.
+    timer: 30s
+
+available_columns:
+    # all columns available to be displayed.
+    - gen                                 # The Generation.
+    - type                                # Type of GC.
+    - pause (ms)                          # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small.
+    - reason                              # Reason for GC.
+    - suspension time (ms)                # The time in milliseconds that it took to suspend all threads to start this GC. For background GCs, we pause multiple times, so this value may be higher than for foreground GCs. 
+    - pause time (%)                      # The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small. 
+    - CPU time (%)                        # Since the last GC, the GC CPU time divided by the total Process CPU time expressed as a percentage. 
+    - gen0 alloc (mb)                     # Amount allocated in Gen0 since the last GC occurred in MB. 
+    - gen0 alloc rate                     # The average allocation rate since the last GC.
+    - peak size (mb)                      # The size on entry of this GC (includes fragmentation) in MB. 
+    - after size (mb)                     # The size on exit of this GC (includes fragmentation) in MB. 
+    - peak/after                          # Peak / After.
+    - promoted (mb)                       # Memory this GC promoted.
+    # Gen0
+    - gen0 size (mb)                      # Size of gen0 at the end of this GC in MB. 
+    - gen0 survival rate                  # The % of objects in Gen0 that survived this GC.
+    - gen0 frag ratio                     # The % of fragmentation on Gen0 at the end of this GC. 
+    # Gen1
+    - gen1 size (mb)                      # Size of gen1 at the end of this GC in MB.
+    - gen1 survival rate                  # The % of objects in Gen1 that survived this GC. Only available if we are doing a gen1 GC.
+    - gen1 frag ratio                     # The % of fragmentation on Gen1 at the end of this GC. 
+    # Gen 2
+    - gen2 size (mb)                      # Size of Gen2 at the end of this GC in MB.
+    - gen2 survival rate                  # The % of objects in Gen2 that survived this GC. Only available if we are doing a gen2 GC.
+    - gen2 frag ratio                     # The % of fragmentation on Gen2 at the end of this GC. 
+    # LOH
+    - LOH size (mb)                       # Size of Large object heap (LOH) at the end of this GC in MB. 
+    - LOH survival rate                   # The % of objects in the large object heap (LOH) that survived the GC. Only available if we are doing a gen2 GC. 
+    - LOH frag ratio                      # The % of fragmentation on the large object heap (LOH) at the end of this GC. 
+    # Finalized and Pinned
+    - finalize promoted (mb)              # The size of finalizable objects that were discovered to be dead and so promoted during this GC, in MB. 
+    - pinned objects                      # Number of pinned objects this GC promoted.

--- a/tests/GCRealTimeMon.UnitTests/ConfigurationReader/ValidateConfiguration.cs
+++ b/tests/GCRealTimeMon.UnitTests/ConfigurationReader/ValidateConfiguration.cs
@@ -54,5 +54,78 @@ namespace realmon.UnitTests
             Action validate = () => ConfigurationReader.ValidateConfiguration(configuration);
             validate.Should().Throw<KeyNotFoundException>();
         }
+
+        [TestMethod]
+        public void ValidateConfiguration_StatsModeEnabledTimerNotSpecified_ShouldThrowArgumentException()
+        {
+            Configuration.Configuration configuration = new Configuration.Configuration();
+            configuration.Columns = new List<string> { "index", "gen" };
+            configuration.AvailableColumns = new List<string> { "gen", "index" };
+            configuration.StatsMode = new Dictionary<string, string>();
+            Action validate = () => ConfigurationReader.ValidateConfiguration(configuration);
+            validate.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ValidateConfiguration_StatsModeEnabledTimerWithoutPeriodMagnitude_ShouldThrowArgumentException()
+        {
+            Configuration.Configuration configuration = new Configuration.Configuration();
+            configuration.Columns = new List<string> { "index", "gen" };
+            configuration.AvailableColumns = new List<string> { "gen", "index" };
+            configuration.StatsMode = new Dictionary<string, string>
+            {
+                { "timer", "m" }
+            };
+
+            Action validate = () => ConfigurationReader.ValidateConfiguration(configuration);
+            validate.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ValidateConfiguration_StatsModeEnabledTimerWithoutPeriodType_ShouldThrowArgumentException()
+        {
+            Configuration.Configuration configuration = new Configuration.Configuration();
+            configuration.Columns = new List<string> { "index", "gen" };
+            configuration.AvailableColumns = new List<string> { "gen", "index" };
+            configuration.StatsMode = new Dictionary<string, string>
+            {
+                { "timer", "20" }
+            };
+
+            Action validate = () => ConfigurationReader.ValidateConfiguration(configuration);
+            validate.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ValidateConfiguration_StatsModeEnabledTimerWithNonIntegerPeriodMagnitude_ShouldThrowArgumentException()
+        {
+            Configuration.Configuration configuration = new Configuration.Configuration();
+            configuration.Columns = new List<string> { "index", "gen" };
+            configuration.AvailableColumns = new List<string> { "gen", "index" };
+            configuration.StatsMode = new Dictionary<string, string>
+            {
+                { "timer", "20.4m" }
+            };
+
+            Action validate = () => ConfigurationReader.ValidateConfiguration(configuration);
+            validate.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ValidateConfiguration_StatsModeEnabledTimerWithCorrectPeriodFormat_SuccessfulValidation()
+        {
+            Configuration.Configuration configuration = new Configuration.Configuration();
+            configuration.Columns = new List<string> { "index", "gen" };
+            configuration.AvailableColumns = new List<string> { "gen", "index" };
+            configuration.StatsMode = new Dictionary<string, string>
+            {
+                { "timer", "20m" }
+            };
+
+            Action validate = () => ConfigurationReader.ValidateConfiguration(configuration);
+            validate.Should().NotThrow<ArgumentException>();
+            validate.Should().NotThrow<ArgumentNullException>();
+            validate.Should().NotThrow<KeyNotFoundException>();
+        }
     }
 }

--- a/tests/GCRealTimeMon.UnitTests/GCRealTimeMon.UnitTests.csproj
+++ b/tests/GCRealTimeMon.UnitTests/GCRealTimeMon.UnitTests.csproj
@@ -24,6 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="ConfigurationReader\TestConfigurations\DefaultWithStatsMode.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="ConfigurationReader\TestConfigurations\Default.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Added the optional ``stats_mode`` configuration for printing heap stats on a timer.  

The format of the period of the timer is given by a period magnitude that's an ``int`` and a period type that's either ``m`` to represent minutes or ``s`` to represent seconds. 

An example of the configuration is: 

```
stats_mode:
    # Print the heap stats on a timer with m: minutes; s: seconds.
    timer: 30s
```

If the stats_mode isn't specified, the user can still press `s` to manually display the heap stats.