### PR TITLE
Remove workaround for NativeAOT

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,7 +9,7 @@ on:
       - '**UnitTests.csproj'
 
 env:
-  DOTNET_VERSION: '6.0.100' # The .NET SDK version to use
+  DOTNET_VERSION: '3.1.x' # The .NET SDK version to use
   TEST_DIR: 'tests/GCRealTimeMon.UnitTests'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Note: Either the name of the process or the process id must be specified, else a
 ## Example Usage
 
 ```
-C:\realmon\src\windows\bin\x64\Release\net5.0>GCRealTimeMon -p 14028
+GCRealTimeMon -p 14028
 ```
 
 or
 
 ```
-C:\realmon\src\windows\bin\x64\Release\net5.0>GCRealTimeMon -n devenv
+GCRealTimeMon -n devenv
 ```
 
 Example output:

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Open ``GCRealTimeMon.sln`` and build it with Visual Studio.
 **Build with command line**
 
 ```bash
+cd src/GCRealTimeMon
 dotnet publish -c Release -r win-x64 # build on Windows
 dotnet publish -c Release -r linux-x64 # build on Linux
 dotnet publish -c Release -r osx-x64 # build on macOS
@@ -143,13 +144,20 @@ Additionaly, you can pass `/p:AotCompilation=true` to build GCRealTimeMon with [
 This requires native C++ toolchain (MSVC or clang) to be installed on the machine.
 
 ```bash
+cd src/GCRealTimeMon
 dotnet publish -c Release -r win-x64 /p:AotCompilation=true # build on Windows
 dotnet publish -c Release -r linux-x64 /p:AotCompilation=true # build on Linux
 dotnet publish -c Release -r osx-x64 /p:AotCompilation=true # build on macOS
 ```
 
-Build artifacts can be found in `bin/Release/net6.0/[rid]/publish`.
+Build artifacts can be found in `bin/Release/netcoreapp3.1/[rid]/publish`.
 
+**Build dotnet-gcmon tool with command line**
+
+```bash
+cd src/dotnet-gcmon
+dotnet build -c Release
+```
 
 ## How to generate the global .NET CLI tool dotnet-gcmon
 

--- a/src/GCRealTimeMon/Configuration/Configuration.cs
+++ b/src/GCRealTimeMon/Configuration/Configuration.cs
@@ -17,19 +17,19 @@ namespace realmon.Configuration
         /// <summary>
         /// All columns available to display. 
         /// </summary>
-        [YamlMember(Description = $"All the Columns Available to Choose From. Please refer to the table via the following link for details about the columns: https://github.com/Maoni0/realmon#configuration")] 
+        [YamlMember(Description = "All the Columns Available to Choose From. Please refer to the table via the following link for details about the columns: https://github.com/Maoni0/realmon#configuration")] 
         public List<string> AvailableColumns { get; set; }
 
         /// <summary>
         /// Stats mode properties. 
         /// </summary>
-        [YamlMember(Description = $"Statistic Mode including timer period for printing Heap Stats.")] 
+        [YamlMember(Description = "Statistic Mode including timer period for printing Heap Stats.")] 
         public Dictionary<string, string> StatsMode { get; set; }
 
         /// <summary>
         /// Display conditions for cases such as min gc pause duration.
         /// </summary>
-        [YamlMember(Description = $"Display conditions such as min gc pause time to display.")] 
+        [YamlMember(Description = "Display conditions such as min gc pause time to display.")] 
         public Dictionary<string, string> DisplayConditions { get; set; }
     }
 }

--- a/src/GCRealTimeMon/Configuration/ConfigurationReader.cs
+++ b/src/GCRealTimeMon/Configuration/ConfigurationReader.cs
@@ -11,7 +11,17 @@ namespace realmon.Configuration
 {
     internal static class ConfigurationReader
     {
-        public static readonly string DefaultPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DefaultConfig.yaml");
+        public static readonly string DefaultPath;
+
+        static ConfigurationReader()
+        {
+            var location = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            // single file mode doesn't support getting the location of an assembly
+            if (string.IsNullOrEmpty(location))
+                DefaultPath = "DefaultConfig.yaml";
+            else
+                DefaultPath = Path.Combine(location, "DefaultConfig.yaml");
+        }
 
         /// <summary>
         /// This method parses the configuration based on the given config path.

--- a/src/GCRealTimeMon/Configuration/NewConfigurationManager.cs
+++ b/src/GCRealTimeMon/Configuration/NewConfigurationManager.cs
@@ -63,7 +63,7 @@ namespace realmon.Configuration
 
             // Heap stats timer.
             bool shouldSetupTimer = Prompt.Confirm("Would you like to setup the heap stats timer?");
-            Dictionary<string, string> statsHeapDict = defaultConfiguration?.StatsMode ?? new();
+            var statsHeapDict = defaultConfiguration?.StatsMode ?? new Dictionary<string, string>();
             if (shouldSetupTimer)
             {
                 // Try to grab the defaults from the specified default config.
@@ -84,7 +84,7 @@ namespace realmon.Configuration
             // Min GC Pause In Msec.
             Console.WriteLine();
             bool shouldSetupMinGCPauseInMsec = Prompt.Confirm("Would you like to set a value for the minimum GC Pause duration to filter GCs off of?");
-            Dictionary<string, string> displayConditions = defaultConfiguration?.DisplayConditions ?? new();
+            var displayConditions = defaultConfiguration?.DisplayConditions ?? new Dictionary<string, string>();
             if (shouldSetupMinGCPauseInMsec)
             {
                 string defaultGCPauseDuration = null;

--- a/src/GCRealTimeMon/Directory.Build.props
+++ b/src/GCRealTimeMon/Directory.Build.props
@@ -12,4 +12,13 @@
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" />
     <RdXmlFile Include="rd.xml" />
   </ItemGroup>
+  <Target Condition="'$(TargetFramework)' != 'net6.0' and '$(AotCompilation)'=='true'"
+          Name="ConfigureTrimming"
+          BeforeTargets="PrepareForILLink">
+    <ItemGroup>
+      <ManagedAssemblyToLink>
+        <TrimMode>link</TrimMode>
+      </ManagedAssemblyToLink>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/GCRealTimeMon/GCRealTimeMon.csproj
+++ b/src/GCRealTimeMon/GCRealTimeMon.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.251802" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.73" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.74" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 

--- a/src/GCRealTimeMon/GCRealTimeMon.csproj
+++ b/src/GCRealTimeMon/GCRealTimeMon.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/src/GCRealTimeMon/Program.cs
+++ b/src/GCRealTimeMon/Program.cs
@@ -185,7 +185,7 @@ namespace realmon
                 if (string.IsNullOrEmpty(location))
                     configurationFile = "DefaultConfig.yaml";
                 else
-                    configurationFile = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DefaultConfig.yaml");
+                    configurationFile = Path.Combine(location, "DefaultConfig.yaml");
             }
             else
             // ensure that the configuration file given on the command line exists

--- a/src/GCRealTimeMon/Program.cs
+++ b/src/GCRealTimeMon/Program.cs
@@ -180,7 +180,10 @@ namespace realmon
             if (string.IsNullOrEmpty(configurationFile))
             {
                 // the default .yaml file is at the same location as the CLI global tool / console application
-                configurationFile = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DefaultConfig.yaml");
+                var location = Assembly.GetExecutingAssembly().Location;
+                // single file mode doesn't support getting the location of an assembly
+                if (string.IsNullOrEmpty(location)) configurationFile = "DefaultConfig.yaml";
+                else configurationFile = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DefaultConfig.yaml");
             }
             else
             // ensure that the configuration file given on the command line exists
@@ -237,7 +240,6 @@ namespace realmon
                 )
             {
                 Console.WriteLine(x.Message);
-
                 // exit on argument/configuration errors
             }
         }

--- a/src/GCRealTimeMon/Program.cs
+++ b/src/GCRealTimeMon/Program.cs
@@ -182,8 +182,10 @@ namespace realmon
                 // the default .yaml file is at the same location as the CLI global tool / console application
                 var location = Assembly.GetExecutingAssembly().Location;
                 // single file mode doesn't support getting the location of an assembly
-                if (string.IsNullOrEmpty(location)) configurationFile = "DefaultConfig.yaml";
-                else configurationFile = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DefaultConfig.yaml");
+                if (string.IsNullOrEmpty(location))
+                    configurationFile = "DefaultConfig.yaml";
+                else
+                    configurationFile = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "DefaultConfig.yaml");
             }
             else
             // ensure that the configuration file given on the command line exists

--- a/src/GCRealTimeMon/rd.xml
+++ b/src/GCRealTimeMon/rd.xml
@@ -3,8 +3,5 @@
         <Assembly Name="System.Private.CoreLib">
             <Type Name="System.Collections.Generic.List`1[[System.String, System.Private.CoreLib]]" Dynamic="Required All" />
         </Assembly>
-        <Assembly Name="OSExtensions">
-            <Type Name="Microsoft.Diagnostics.Tracing.Extensions.ETWControl" Dynamic="Required All" />
-        </Assembly>
     </Application>
 </Directives>

--- a/src/dotnet-gcmon/dotnet-gcmon.csproj
+++ b/src/dotnet-gcmon/dotnet-gcmon.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>dotnet-gcmon</PackageId>
-    <PackageVersion>0.2.0</PackageVersion>
+    <PackageVersion>0.3.0</PackageVersion>
     <Title>dotnet-gcmon</Title>
     <Owners>Maoni0</Owners>
     <Authors>Maoni Stephens</Authors>

--- a/src/dotnet-gcmon/dotnet-gcmon.csproj
+++ b/src/dotnet-gcmon/dotnet-gcmon.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>dotnet-gcmon</PackageId>
-    <PackageVersion>0.3.0</PackageVersion>
+    <PackageVersion>0.4.0</PackageVersion>
     <Title>dotnet-gcmon</Title>
     <Owners>Maoni0</Owners>
     <Authors>Maoni Stephens</Authors>

--- a/src/dotnet-gcmon/dotnet-gcmon.csproj
+++ b/src/dotnet-gcmon/dotnet-gcmon.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
     <RootNamespace>realmon</RootNamespace>
 
@@ -39,14 +39,14 @@
 
   <!--add LICENCE.txt file to the package (PackageLicenceUlr no more supported)-->
   <ItemGroup>
-    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.251802" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.73" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.74" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 

--- a/src/dotnet-gcmon/dotnet-gcmon.csproj
+++ b/src/dotnet-gcmon/dotnet-gcmon.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     <RootNamespace>realmon</RootNamespace>
 

--- a/tests/GCRealTimeMon.UnitTests/GCRealTimeMon.UnitTests.csproj
+++ b/tests/GCRealTimeMon.UnitTests/GCRealTimeMon.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
Since https://github.com/dotnet/runtimelab/pull/1728 fixed the issue where some metadata is missing after compilation, I removed the workaround in `rd.xml`.

Also fixes #20