### PR TITLE
Only subscribe to the runtime events for the process requested by the user

### DIFF
--- a/src/GCRealTimeMon/Program.cs
+++ b/src/GCRealTimeMon/Program.cs
@@ -64,24 +64,27 @@ namespace realmon
             monitorThread.Start();
 
             source.NeedLoadedDotNetRuntimes();
-            source.AddCallbackOnProcessStart(delegate (TraceProcess proc)
+            source.AddCallbackOnProcessStart((TraceProcess proc) =>
             {
-                proc.AddCallbackOnDotNetRuntimeLoad(delegate (TraceLoadedDotNetRuntime runtime)
+                // if the process id doesn't match that of one requested, don't register any runtime events for it.
+                if (proc.ProcessID != pid)
+                {
+                    return;
+                }
+
+                proc.AddCallbackOnDotNetRuntimeLoad((TraceLoadedDotNetRuntime runtime) =>
                 {
                     runtime.GCEnd += delegate (TraceProcess p, TraceGC gc)
                     {
-                        if (p.ProcessID == pid)
+                        // If no min duration is specified or if the min duration specified is less than the pause duration, log the event.
+                        if (!minDurationForGCPausesInMSec.HasValue ||
+                            (minDurationForGCPausesInMSec.HasValue && minDurationForGCPausesInMSec.Value < gc.PauseDurationMSec))
                         {
-                            // If no min duration is specified or if the min duration specified is less than the pause duration, log the event.
-                            if (!minDurationForGCPausesInMSec.HasValue ||
-                                (minDurationForGCPausesInMSec.HasValue && minDurationForGCPausesInMSec.Value < gc.PauseDurationMSec))
-                            {
-                                lastGCTime = DateTime.UtcNow;
-                                lastGC = gc;
+                            lastGCTime = DateTime.UtcNow;
+                            lastGC = gc;
 
-                                lock (writerLock) {
-                                    Console.WriteLine(PrintUtilities.GetRowDetails(gc, configuration));
-                                }
+                            lock (writerLock) {
+                                Console.WriteLine(PrintUtilities.GetRowDetails(gc, configuration));
                             }
                         }
                     };

--- a/src/dotnet-gcmon/dotnet-gcmon.csproj
+++ b/src/dotnet-gcmon/dotnet-gcmon.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <PackageId>dotnet-gcmon</PackageId>
-    <PackageVersion>0.3.0</PackageVersion>
+    <PackageVersion>0.4.0</PackageVersion>
     <Title>dotnet-gcmon</Title>
     <Owners>Maoni0</Owners>
     <Authors>Maoni Stephens</Authors>


### PR DESCRIPTION
To help with #23, only subscribe to GC events for the process requested by the user; we are currently subscribing to all processes' GC data, a majority of which we are not using.