### PR TITLE
Added the ability to request call stacks for induced GCs and large object allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@ Right now it's super simple - given a PID or process name it will show you a few
 |-----|-----|-----|
 | n | Name of the Process | Grabs the first process with the name matching that with the one specified with this argument |
 | p | Process Id | Process Id to monitor GC for |
-| c | Path of a YAML configuration File to use | This can be used to override default configuration either through another file or manual column selection that will also update the default when no file is provided. |
-| g | Path of a YAML configuration file to generate | Select the columns to display and the corresponding configuration will be saved to the given YAML file and used for the current monitoring session.|
+| c | Path of the Configuration File | Path to the configuration file used by the monitor. This file is a YAML file. By default, it's the Default.yaml file is loaded. If no argument is specified, the command line prompt to create the config will be displayed and the default config will be overwritten with the inputted values; this new config will be used for this session. | 
+| g | Path of the New Configuration File | Path to the configuration file that'll be created using a command line prompt, persisted to the given path and used by the monitor for this particular session. This file will be of the YAML format. |
+| s | Flag to enable Call Stacks | Passing the 's' command line option will enable displaying call stacks for induced GCs and large object allocations. This mode is currently only available for Windows and only if realmon is run with admin privileges. | 
 
-Note: Either the name of the process or the process id must be specified, else an ``ArgumentException`` is thrown.
-
-## Runtime Keys
+  ## Runtime Keys
 
 | Key | Action |
 |-----|-----|
@@ -109,6 +108,31 @@ Currently, the available columns are:
 | LOH frag ratio         | The % of fragmentation on the large object heap (LOH) at the end of this GC.                                                                                                     | `TraceGC.GenFragmentationPercent(Gens.LargeObj)`                                          |
 | finalize promoted (mb) | The size of finalizable objects that were discovered to be dead and so promoted during this GC, in MB.                                                                           | `TraceGC.HeapStats.FinalizationPromotedSize / 1000000.0`                                  |
 | pinned objects         | Number of pinned objects observed in this GC.                                                                                                                                    | `TraceGC.HeapStats.PinnedObjectCount`                                                     |
+
+## Call Stacks
+
+In an effort to aid with perf diagnosis, call stacks are currently available for induced GCs and large object allocations on Windows, only. Enabling call stacks requires the process to run with administrator privileges.
+
+### Troubleshooting
+
+#### Symbols aren't properly resolved
+
+The symbol resolution logic relies on the fact that _NT_SYMBOL_PATH is populated with the appropriate symbol path(s). More details on how this can be troubleshooted [here](https://docs.microsoft.com/en-us/visualstudio/profiling/how-to-specify-symbol-file-locations-from-the-command-line?view=vs-2017).
+
+An example of the _NT_SYMBOL_PATH is:
+``;SRV*C:\Symbols*https://msdl.microsoft.com/download/symbols;SRV*C:\Symbols*https://nuget.smbsrc.net;SRV*C:\Symbols*https://referencesource.microsoft.com/symbols``
+
+#### Getting the following exception: ``Unhandled exception. System.Runtime.InteropServices.COMException (0x800705AA): Insufficient system resources exist to complete the requested service. (0x800705AA)`` 
+
+This exception is thrown as a result of session exhaustion i.e. enough sessions are being created that you're unable to create another. You can troubleshoot this issue in 2 ways:
+
+1. Rebooting your machine will clear up any zombie sessions.
+2. Manually stopping sessions
+   1. Open up a command prompt / powershell instance in admin mode.
+   2. Enter the following command to check to view the list of all the sessions: ``logman query -ets``.
+   3. Stop dangling session(s) using: ``logman -ets stop <NameOfSession>``.
+
+More details on this issue can be found [here](https://github.com/microsoft/perfview/issues/1166).
 
 ## Adding New Columns
 

--- a/src/GCRealTimeMon/CallStackResolution/CallStackManager.cs
+++ b/src/GCRealTimeMon/CallStackResolution/CallStackManager.cs
@@ -33,6 +33,7 @@ namespace realmon.CallStackResolution
              KernelTraceEventParser.Keywords.None
              );
 
+            // Needed for the GC events + call stacks.
             traceEventSession.EnableProvider(
                 ClrTraceEventParser.ProviderGuid,
                 TraceEventLevel.Verbose, // Verbose needed for call stacks.
@@ -40,6 +41,7 @@ namespace realmon.CallStackResolution
                 ClrTraceEventParser.Keywords.Loader |
                 ClrTraceEventParser.Keywords.Stack));
 
+            // Needed for JIT Compile code that was already compiled. 
             traceEventSession.EnableProvider(ClrRundownTraceEventParser.ProviderGuid, TraceEventLevel.Informational,
                 (ulong)(ClrTraceEventParser.Keywords.Jit |
                 ClrTraceEventParser.Keywords.Loader |
@@ -73,13 +75,13 @@ namespace realmon.CallStackResolution
             var callStack = data.CallStack();
             if (callStack != null)
             {
-                ResolveNativeCode(callStack);
+                ResolveSymbols(callStack);
                 PrintCallStack(callStack);
             }
             Console.WriteLine(PrintUtilities.GetLineSeparator(configuration));
         }
 
-        internal static void ResolveNativeCode(TraceCallStack callStack)
+        internal static void ResolveSymbols(TraceCallStack callStack)
         {
             while (callStack != null)
             {

--- a/src/GCRealTimeMon/CallStackResolution/CallStackManager.cs
+++ b/src/GCRealTimeMon/CallStackResolution/CallStackManager.cs
@@ -1,0 +1,120 @@
+﻿using Microsoft.Diagnostics.Symbols;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using Microsoft.Diagnostics.Tracing.Session;
+using realmon.Utilities;
+using System;
+using System.IO;
+
+namespace realmon.CallStackResolution
+{
+    public static class CallStackManager
+    {
+        private static SymbolReader m_symbolReader;
+
+        public static TraceLogEventSource InitializeAndRegisterCallStacks(Configuration.Configuration configuration, 
+                                                                          TraceEventSession traceEventSession, 
+                                                                          int processId)
+        {
+            // TODO: Add configurations for the Symbol Reader Text Output path and the NT_SymbolPath.
+            m_symbolReader = new SymbolReader(TextWriter.Null, SymbolPath.SymbolPathFromEnvironment); 
+            m_symbolReader.SecurityCheck = path => true;
+
+            // Setup the additional providers needed for the enabling of the callstacks.
+            // Image Load and Process needed for Native Symbol Resolution.
+            // Requires Admin privileges, else this will throw.
+            traceEventSession.EnableKernelProvider(
+                flags:
+             KernelTraceEventParser.Keywords.ImageLoad |
+             KernelTraceEventParser.Keywords.Process,
+                stackCapture:
+             KernelTraceEventParser.Keywords.None
+             );
+
+            traceEventSession.EnableProvider(
+                ClrTraceEventParser.ProviderGuid,
+                TraceEventLevel.Verbose, // Verbose needed for call stacks.
+                (ulong)(ClrTraceEventParser.Keywords.GC |
+                ClrTraceEventParser.Keywords.Loader |
+                ClrTraceEventParser.Keywords.Stack));
+
+            traceEventSession.EnableProvider(ClrRundownTraceEventParser.ProviderGuid, TraceEventLevel.Informational,
+                (ulong)(ClrTraceEventParser.Keywords.Jit |
+                ClrTraceEventParser.Keywords.Loader |
+                ClrTraceEventParser.Keywords.StartEnumeration));
+
+            // Subscribe to the requested events.
+            TraceLogEventSource traceLogEventSource = TraceLog.CreateFromTraceEventSession(traceEventSession);
+            traceLogEventSource.TraceLog.Clr.GCTriggered += (GCTriggeredTraceData traceEvent) =>
+            {
+                if (traceEvent.Reason == GCReason.Induced && processId == traceEvent.ProcessID)
+                {
+                    PrintCallStack(traceEvent, configuration);
+                }
+            };
+
+            traceLogEventSource.TraceLog.Clr.GCAllocationTick += (GCAllocationTickTraceData traceEvent) =>
+            {
+                if (traceEvent.AllocationKind == GCAllocationKind.Large && processId == traceEvent.ProcessID)
+                {
+                    PrintCallStack(traceEvent, configuration);
+                }
+            };
+
+            return traceLogEventSource;
+        }
+
+        internal static void PrintCallStack(TraceEvent data, Configuration.Configuration configuration)
+        {
+            Console.WriteLine(PrintUtilities.GetLineSeparator(configuration));
+            Console.WriteLine($"Callstack Type: {data.EventName}\n");
+            var callStack = data.CallStack();
+            if (callStack != null)
+            {
+                ResolveNativeCode(callStack);
+                PrintCallStack(callStack);
+            }
+            Console.WriteLine(PrintUtilities.GetLineSeparator(configuration));
+        }
+
+        internal static void ResolveNativeCode(TraceCallStack callStack)
+        {
+            while (callStack != null)
+            {
+                var codeAddress = callStack.CodeAddress;
+                if (codeAddress.Method == null)
+                {
+                    var moduleFile = codeAddress.ModuleFile;
+                    if (moduleFile != null)
+                    {
+                        codeAddress.CodeAddresses.LookupSymbolsForModule(m_symbolReader, moduleFile);
+                    }
+                }
+
+                callStack = callStack.Caller;
+            }
+        }
+
+        internal static void PrintCallStack(TraceCallStack callStack)
+        {
+            while (callStack != null)
+            {
+                var codeAddress = callStack.CodeAddress;
+
+                // Like WinDbg, display unresolved modules with the address in Hex form.
+                if (codeAddress.ModuleFile == null)
+                {
+                    Console.WriteLine("0x{0:x}", codeAddress.Address);
+                }
+                else
+                {
+                    Console.WriteLine($"{codeAddress.ModuleName}!{codeAddress.FullMethodName}");
+                }
+
+                callStack = callStack.Caller;
+            }
+        }
+    }
+}

--- a/src/GCRealTimeMon/CallStackResolution/CallStackManager.cs
+++ b/src/GCRealTimeMon/CallStackResolution/CallStackManager.cs
@@ -52,7 +52,6 @@ namespace realmon.CallStackResolution
                 ClrTraceEventParser.Keywords.JittedMethodILToNativeMap |
                 ClrTraceEventParser.Keywords.JITSymbols                |
                 ClrTraceEventParser.Keywords.JitTracing                |
-                ClrTraceEventParser.Keywords.GCAllObjectAllocation     |
                 ClrTraceEventParser.Keywords.Jit                       |
                 ClrTraceEventParser.Keywords.Codesymbols               |
                 ClrTraceEventParser.Keywords.Interop                   |
@@ -67,7 +66,6 @@ namespace realmon.CallStackResolution
                 ClrTraceEventParser.Keywords.JittedMethodILToNativeMap |
                 ClrTraceEventParser.Keywords.JITSymbols                |
                 ClrTraceEventParser.Keywords.Jit                       |
-                ClrTraceEventParser.Keywords.GCAllObjectAllocation     |
                 ClrTraceEventParser.Keywords.JitTracing                |
                 ClrTraceEventParser.Keywords.Codesymbols               |
                 ClrTraceEventParser.Keywords.Interop                   |

--- a/src/GCRealTimeMon/CallStackResolution/CallStackManager.cs
+++ b/src/GCRealTimeMon/CallStackResolution/CallStackManager.cs
@@ -39,12 +39,22 @@ namespace realmon.CallStackResolution
                 TraceEventLevel.Verbose, // Verbose needed for call stacks.
                 (ulong)(ClrTraceEventParser.Keywords.GC |
                 ClrTraceEventParser.Keywords.Loader |
+                ClrTraceEventParser.Keywords.JittedMethodILToNativeMap |
+                ClrTraceEventParser.Keywords.JITSymbols |
+                ClrTraceEventParser.Keywords.Jit |
+                ClrTraceEventParser.Keywords.StartEnumeration |
+                ClrTraceEventParser.Keywords.NGen |
+                ClrTraceEventParser.Keywords.MethodDiagnostic |
                 ClrTraceEventParser.Keywords.Stack));
 
             // Needed for JIT Compile code that was already compiled. 
             traceEventSession.EnableProvider(ClrRundownTraceEventParser.ProviderGuid, TraceEventLevel.Verbose,
                 (ulong)(ClrTraceEventParser.Keywords.Jit |
                 ClrTraceEventParser.Keywords.Loader |
+                ClrTraceEventParser.Keywords.NGen |
+                ClrTraceEventParser.Keywords.JITSymbols |
+                ClrTraceEventParser.Keywords.JittedMethodILToNativeMap |
+                ClrTraceEventParser.Keywords.MethodDiagnostic |
                 ClrTraceEventParser.Keywords.StartEnumeration));
 
             // Subscribe to the requested events.
@@ -59,8 +69,9 @@ namespace realmon.CallStackResolution
 
             traceLogEventSource.TraceLog.Clr.GCAllocationTick += (GCAllocationTickTraceData traceEvent) =>
             {
-                if (traceEvent.AllocationKind == GCAllocationKind.Large && processId == traceEvent.ProcessID)
+                if (traceEvent.AllocationKind == GCAllocationKind.Large /**&& processId == traceEvent.ProcessID**/)
                 {
+                    Console.WriteLine($"ProcessName: {traceEvent.ProcessName}");
                     PrintCallStack(traceEvent, configuration);
                 }
             };

--- a/src/GCRealTimeMon/CallStackResolution/CallStackManager.cs
+++ b/src/GCRealTimeMon/CallStackResolution/CallStackManager.cs
@@ -42,7 +42,7 @@ namespace realmon.CallStackResolution
                 ClrTraceEventParser.Keywords.Stack));
 
             // Needed for JIT Compile code that was already compiled. 
-            traceEventSession.EnableProvider(ClrRundownTraceEventParser.ProviderGuid, TraceEventLevel.Informational,
+            traceEventSession.EnableProvider(ClrRundownTraceEventParser.ProviderGuid, TraceEventLevel.Verbose,
                 (ulong)(ClrTraceEventParser.Keywords.Jit |
                 ClrTraceEventParser.Keywords.Loader |
                 ClrTraceEventParser.Keywords.StartEnumeration));

--- a/src/GCRealTimeMon/Program.cs
+++ b/src/GCRealTimeMon/Program.cs
@@ -69,8 +69,8 @@ namespace realmon
             consoleOut.WriteProcessInfo(process.ProcessName, pid);
             consoleOut.WriteTableHeaders();
 
-            var source = PlatformUtilities.GetTraceEventDispatcherBasedOnPlatform(configuration: configuration, 
-                                                                                  processId: pid, 
+            var source = PlatformUtilities.GetTraceEventDispatcherBasedOnPlatform(processId: pid, 
+                                                                                  consoleOut: consoleOut,
                                                                                   enableCallStacks: options.EnableCallStacks,
                                                                                   out var session);
             Console.CancelKeyPress += (_, e) =>

--- a/src/GCRealTimeMon/Program.cs
+++ b/src/GCRealTimeMon/Program.cs
@@ -41,6 +41,12 @@ HelpText = "The path to the YAML columns configuration file used during the sess
                     HelpText = "The path of the YAML configuration file to be generated based on the colums selection available in the command prompt.")]
             public string PathToNewConfigurationFile { get; set; } = null;
 
+            [Option(shortName: 's',
+                    longName: "callStacks",
+                    Required = false,
+                    HelpText = "Setting this option will enable call stacks for induced GCs and large object allocations. Getting call stacks will currently only work for Windows and the session must have admin privileges.")]
+            public bool EnableCallStacks { get; set; } = false;
+
             [Option(shortName: '?',
                     longName: "\\?",
                     Required = false,
@@ -68,7 +74,10 @@ HelpText = "The path to the YAML columns configuration file used during the sess
             Console.WriteLine(PrintUtilities.GetHeader(configuration));
             Console.WriteLine(PrintUtilities.GetLineSeparator(configuration));
 
-            var source = PlatformUtilities.GetTraceEventDispatcherBasedOnPlatform(pid, out var session);
+            var source = PlatformUtilities.GetTraceEventDispatcherBasedOnPlatform(configuration: configuration, 
+                                                                                  processId: pid, 
+                                                                                  enableCallStacks: options.EnableCallStacks,
+                                                                                  out var session);
 
             // this thread is responsible for listening to user input on the console and dispose the session accordingly
             Thread monitorThread = new Thread(() => HandleConsoleInput(session)) ;

--- a/src/GCRealTimeMon/Program.cs
+++ b/src/GCRealTimeMon/Program.cs
@@ -74,6 +74,10 @@ HelpText = "The path to the YAML columns configuration file used during the sess
             Console.WriteLine(PrintUtilities.GetHeader(configuration));
             Console.WriteLine(PrintUtilities.GetLineSeparator(configuration));
 
+            var source = PlatformUtilities.GetTraceEventDispatcherBasedOnPlatform(configuration: configuration, 
+                                                                                  processId: pid, 
+                                                                                  enableCallStacks: options.EnableCallStacks,
+                                                                                  out var session);
             Console.CancelKeyPress += (_, e) =>
             {
                 // Dispose the session.
@@ -81,10 +85,6 @@ HelpText = "The path to the YAML columns configuration file used during the sess
                 // Exit the process.
                 Environment.Exit(0);
             };
-            var source = PlatformUtilities.GetTraceEventDispatcherBasedOnPlatform(configuration: configuration, 
-                                                                                  processId: pid, 
-                                                                                  enableCallStacks: options.EnableCallStacks,
-                                                                                  out var session);
 
             // this thread is responsible for listening to user input on the console and dispose the session accordingly
             Thread monitorThread = new Thread(() => HandleConsoleInput(session)) ;

--- a/src/GCRealTimeMon/Utilities/IConsoleOut.cs
+++ b/src/GCRealTimeMon/Utilities/IConsoleOut.cs
@@ -11,6 +11,7 @@ namespace realmon.Utilities
     internal interface IConsoleOut
     {
         void WriteProcessInfo(string processName, int pid);
+        void WriteLineSeparator();
         void WriteRow(TraceGC gc);
         void WriteTableHeaders();
         Task PrintLastStatsAsync(CapturedGCEvent lastGC);

--- a/src/GCRealTimeMon/Utilities/IConsoleOut.cs
+++ b/src/GCRealTimeMon/Utilities/IConsoleOut.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Diagnostics.Tracing.Analysis.GC;
+using Microsoft.Diagnostics.Tracing.Etlx;
 
 namespace realmon.Utilities
 {
@@ -12,6 +13,7 @@ namespace realmon.Utilities
         void WriteRow(TraceGC gc);
         void WriteTableHeaders();
         Task PrintLastStatsAsync(CapturedGCEvent lastGC);
+        Task PrintCallStack(TraceCallStack callstack, string eventName);
         void WriteStatsUsage();
     }
 }

--- a/src/GCRealTimeMon/Utilities/PlainTextConsoleOut.cs
+++ b/src/GCRealTimeMon/Utilities/PlainTextConsoleOut.cs
@@ -34,6 +34,11 @@ namespace realmon.Utilities
             Console.WriteLine($"Monitoring process with name: {processName} and pid: {pid}");
         }
 
+        public void WriteLineSeparator()
+        {
+            Console.WriteLine(PrintUtilities.LineSeparator);
+        }
+
         public void WriteRow(TraceGC gc)
         {
             lock (writerLock)
@@ -45,7 +50,7 @@ namespace realmon.Utilities
         public void WriteTableHeaders()
         {
             Console.WriteLine(PrintUtilities.GetHeader(configuration));
-            Console.WriteLine(PrintUtilities.GetLineSeparator(configuration));
+            WriteLineSeparator();
         }
 
         public Task PrintLastStatsAsync(CapturedGCEvent lastGC)
@@ -60,7 +65,7 @@ namespace realmon.Utilities
                 var s = lastGC.Data.HeapStats;
                 lock (writerLock)
                 {
-                    Console.WriteLine(PrintUtilities.LineSeparator);
+                    WriteLineSeparator();
                     Console.WriteLine("Heap Stats as of {0:u} (Run {1} for gen {2}):", lastGC.Time, t.Number, t.Generation);
                     Console.WriteLine("  Heaps: {0:N0}", t.HeapCount);
                     Console.WriteLine("  Handles: {0:N0}", s.GCHandleCount);
@@ -72,7 +77,7 @@ namespace realmon.Utilities
                     Console.WriteLine("      Gen 2: {0,17:N0} Bytes", s.GenerationSize2);
                     Console.WriteLine("      Gen 3: {0,17:N0} Bytes", s.GenerationSize3);
                     Console.WriteLine("      Gen 4: {0,17:N0} Bytes", s.GenerationSize4);
-                    Console.WriteLine(PrintUtilities.LineSeparator);
+                    WriteLineSeparator();
                 }
             }
 
@@ -83,7 +88,7 @@ namespace realmon.Utilities
         {
             lock (writerLock)
             {
-                Console.WriteLine(PrintUtilities.LineSeparator);
+                WriteLineSeparator();
                 Console.WriteLine($"CallStack For {eventName}:");
                 while (callstack != null)
                 {
@@ -102,7 +107,7 @@ namespace realmon.Utilities
                     callstack = callstack.Caller;
                 }
 
-                Console.WriteLine(PrintUtilities.LineSeparator);
+                WriteLineSeparator();
             }
 
             return Task.CompletedTask;

--- a/src/GCRealTimeMon/Utilities/PlatformUtilities.cs
+++ b/src/GCRealTimeMon/Utilities/PlatformUtilities.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
-using Microsoft.Diagnostics.Tracing.Etlx;
 using Microsoft.Diagnostics.Tracing.Parsers;
 using Microsoft.Diagnostics.Tracing.Session;
 using System;
@@ -12,8 +11,8 @@ namespace realmon.Utilities
 {
     internal static class PlatformUtilities
     {
-        public static TraceEventDispatcher GetTraceEventDispatcherBasedOnPlatform(Configuration.Configuration configuration,
-                                                                                  int processId, 
+        public static TraceEventDispatcher GetTraceEventDispatcherBasedOnPlatform(int processId, 
+                                                                                  IConsoleOut consoleOut,
                                                                                   bool enableCallStacks,
                                                                                   out IDisposable session)
         {
@@ -24,8 +23,8 @@ namespace realmon.Utilities
                 // If the user requested call stacks, enable them via the CallStackManager.
                 if (enableCallStacks)
                 {
-                    CallStackResolution.CallStackManager.InitializeAndRegisterCallStacks(configuration: configuration,
-                                                                                         traceEventSession: traceEventSession,
+                    CallStackResolution.CallStackManager.InitializeAndRegisterCallStacks(traceEventSession: traceEventSession,
+                                                                                         consoleOut: consoleOut,
                                                                                          processId: processId);
                 }
 

--- a/src/GCRealTimeMon/Utilities/PrintUtilities.cs
+++ b/src/GCRealTimeMon/Utilities/PrintUtilities.cs
@@ -8,7 +8,7 @@ namespace realmon.Utilities
 {
     internal static class PrintUtilities
     {
-        public const string HeapStatsLineSeparator = "------------------------------------------------------------------------------";
+        public const string LineSeparator = "------------------------------------------------------------------------------";
 
         /// <summary>
         /// Gets the header of the monitor table based on the configuration.

--- a/src/GCRealTimeMon/Utilities/SpectreConsoleOut.cs
+++ b/src/GCRealTimeMon/Utilities/SpectreConsoleOut.cs
@@ -31,6 +31,14 @@
             WriteRule($"[{ThemeConfig.Current.MessageColor}]Monitoring process with name: [{ThemeConfig.Current.HighlightColor}]{processName}[/] and pid: [{ThemeConfig.Current.HighlightColor}]{pid}[/][/]");
         }
 
+        /// <summary>
+        /// Writes a horizontal rule line to the console.
+        /// </summary>
+        public void WriteLineSeparator()
+        {
+            AnsiConsole.Write(new Rule().RuleStyle(Style.Parse(ThemeConfig.Current.MessageColor)));
+        }
+
         public void WriteTableHeaders() => liveOutputTable.Start();
 
         public void WriteRow(TraceGC gc) => liveOutputTable.WriteRow(gc);
@@ -42,14 +50,6 @@
         public void WriteRule(string ruleMessage)
         {
             AnsiConsole.Write(new Rule(ruleMessage).RuleStyle(Style.Parse(ThemeConfig.Current.MessageColor)));
-        }
-
-        /// <summary>
-        /// Writes a horizontal rule line to the console.
-        /// </summary>
-        public void WriteRule()
-        {
-            AnsiConsole.Write(new Rule().RuleStyle(Style.Parse(ThemeConfig.Current.MessageColor)));
         }
 
         /// <summary>
@@ -71,7 +71,7 @@
             }
             else
             {
-                WriteRule();
+                WriteLineSeparator();
                 GCHeapStats heapStats = lastGC.Data.HeapStats;
 
                 Table table = new Table().HideHeaders();
@@ -111,7 +111,7 @@
                      .Header(ThemeConfig.ToMessage("Last Run Stats:")));
 
                 AnsiConsole.Write(table);
-                WriteRule();
+                WriteLineSeparator();
             }
 
             liveOutputTable.Start();
@@ -126,7 +126,8 @@
         {
             await liveOutputTable.StopAsync();
 
-            WriteRule();
+            WriteLineSeparator();
+
 
             Tree rootOfCallStack = new Tree($"[{ThemeConfig.Current.GCTableHeaderColor}]CallStack for: {eventName}:[/]");
             while (callstack != null)
@@ -147,7 +148,7 @@
                 callstack = callstack.Caller;
             }
             AnsiConsole.Write(rootOfCallStack);
-            WriteRule();
+            WriteLineSeparator();
 
             liveOutputTable.Start();
         }

--- a/src/dotnet-gcmon/dotnet-gcmon.csproj
+++ b/src/dotnet-gcmon/dotnet-gcmon.csproj
@@ -37,11 +37,12 @@
     <Compile Include="..\GCRealTimeMon\Utilities\PlatformUtilities.cs" Link="Utilities\PlatformUtilities.cs" />
     <Compile Include="..\GCRealTimeMon\Utilities\PrintUtilities.cs" Link="Utilities\PrintUtilities.cs" />
     <Compile Include="..\GCRealTimeMon\Utilities\CommandLineUtilities.cs" Link="Utilities\CommandLineUtilities.cs" />
+    <Compile Include="..\GCRealTimeMon\CallStackResolution\CallStackManager.cs" Link="CallStackResolution\CallStackManager.cs" />
   </ItemGroup>
 
   <!--add LICENCE.txt file to the package (PackageLicenceUlr no more supported)-->
   <ItemGroup>
-    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 
@@ -57,6 +58,10 @@
     <None Include="..\GCRealTimeMon\DefaultConfig.yaml" Pack="true" PackagePath="">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GCRealTimeMon\GCRealTimeMon.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/dotnet-gcmon/dotnet-gcmon.csproj
+++ b/src/dotnet-gcmon/dotnet-gcmon.csproj
@@ -60,8 +60,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\GCRealTimeMon\GCRealTimeMon.csproj" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Call stacks are now available for induced GCs and large object allocations by passing in the ``-s`` flag. These call stacks are currently only available in Windows and require admin privileges to be run.  This is an effort to close #8 

An example of the call stacks are:
![image](https://user-images.githubusercontent.com/4951960/144384171-e7934916-48bf-4685-90a6-4ac1d56e07ad.png)

To ensure the successful resolution of the symbols, ensure that the ``_NT_SYMBOL_PATH`` is set correctly. While testing, I had it set to:

``
;SRV*C:\Symbols*https://msdl.microsoft.com/download/symbols;SRV*C:\Symbols*https://nuget.smbsrc.net;SRV*C:\Symbols*https://referencesource.microsoft.com/symbols
``

Note:
- There are cases where certain symbols aren't resolved such as ``0x7ffc8ea167d6`` in the image above. These take place when the ModuleFile is null => information about the code address is unavailable. 

Follow Ups to this PR include:
- Moving the enabling of the call stacks as a configuration rather than a command line option.
- Configuring the symbol resolution log file.
- Enabling different symbol reader modes such as reading only from Cache/ not resolving Ngen'd symbols.
- Optionally choosing specifically what call stacks are requested i.e. only induced gcs or only large object allocations.