### PR TITLE
Decoupled the Console Presentation from the Core Logic into a Service

### DIFF
--- a/src/GCRealTimeMon/GCRealTimeMon.csproj
+++ b/src/GCRealTimeMon/GCRealTimeMon.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.251802" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.74" />
     <PackageReference Include="Sharprompt" Version="2.3.7" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 

--- a/src/GCRealTimeMon/Service/GCRealTimeMonService.cs
+++ b/src/GCRealTimeMon/Service/GCRealTimeMonService.cs
@@ -65,13 +65,12 @@ namespace realmon.Service
             {
                 m_gcEndSubject = gcEndSubject;
                 Source = source;
-                Session = session;
+                m_session = session;
             }
 
             private bool disposedValue;
 
             public IObservable<TraceGC> GCEndObservable => m_gcEndSubject;
-            public IDisposable Session { get; }
             public TraceEventDispatcher Source { get; } 
 
             private void Dispose(bool disposing)
@@ -81,7 +80,7 @@ namespace realmon.Service
                 if (!disposedValue)
                 {
                     Source?.Dispose();
-                    Session?.Dispose();
+                    m_session?.Dispose();
                     m_gcEndSubject = null;
                     disposedValue = true;
                 }

--- a/src/GCRealTimeMon/Service/GCRealTimeMonService.cs
+++ b/src/GCRealTimeMon/Service/GCRealTimeMonService.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Analysis;
+using Microsoft.Diagnostics.Tracing.Analysis.GC;
+using realmon.Utilities;
+using System;
+using System.Reactive.Subjects;
+
+namespace realmon.Service
+{
+    internal sealed class GCRealTimeMonService : IGCRealTimeMonService
+    {
+        public static Lazy<IGCRealTimeMonService> Instance = new Lazy<IGCRealTimeMonService>(new GCRealTimeMonService());
+
+        public IGCRealTimeMonResult Initialize(int pid, Configuration.Configuration configuration)
+        {
+            double? minDurationForGCPausesInMSec = null;
+            if (configuration.DisplayConditions != null && 
+                configuration.DisplayConditions.TryGetValue("min gc duration (msec)", out var minDuration))
+            {
+                minDurationForGCPausesInMSec = double.Parse(minDuration);
+            }
+
+            var source = PlatformUtilities.GetTraceEventDispatcherBasedOnPlatform(pid, out var session);
+            Subject<TraceGC> gcEndSubject = new Subject<TraceGC>();
+            source.NeedLoadedDotNetRuntimes();
+            source.AddCallbackOnProcessStart((TraceProcess proc) =>
+            {
+                if (proc.ProcessID != pid)
+                {
+                    return;
+                }
+
+                Action<TraceProcess, TraceGC> gcEndAction = 
+                    (p, gc) =>
+                    {
+                        if (p.ProcessID == pid)
+                        {
+                            // If no min duration is specified or if the min duration specified is less than the pause duration, log the event.
+                            if (!minDurationForGCPausesInMSec.HasValue ||
+                                (minDurationForGCPausesInMSec.HasValue && minDurationForGCPausesInMSec.Value < gc.PauseDurationMSec))
+                            {
+                                gcEndSubject.OnNext(gc);
+                            }
+                        }
+                    };
+
+                proc.AddCallbackOnDotNetRuntimeLoad((TraceLoadedDotNetRuntime runtime) =>
+                {
+                    // TODO: When there are multiple clients, fix this leak by unsubscribing. 
+                    runtime.GCEnd += gcEndAction; 
+                });
+            });
+
+            return new GCRealTimeMonResult(gcEndSubject: gcEndSubject, 
+                                           source: source,
+                                           session: session);
+        }
+
+        private sealed class GCRealTimeMonResult : IGCRealTimeMonResult 
+        {
+            private Subject<TraceGC> m_gcEndSubject;
+            private IDisposable m_session;
+
+            public GCRealTimeMonResult(Subject<TraceGC> gcEndSubject, TraceEventDispatcher source, IDisposable session)
+            {
+                m_gcEndSubject = gcEndSubject;
+                Source = source;
+                Session = session;
+            }
+
+            private bool disposedValue;
+
+            public IObservable<TraceGC> GCEndObservable => m_gcEndSubject;
+            public IDisposable Session { get; }
+            public TraceEventDispatcher Source { get; } 
+
+            private void Dispose(bool disposing)
+            {
+                m_gcEndSubject?.Dispose();
+
+                if (!disposedValue)
+                {
+                    Source?.Dispose();
+                    Session?.Dispose();
+                    m_gcEndSubject = null;
+                    disposedValue = true;
+                }
+            }
+
+             ~GCRealTimeMonResult()
+             {
+                 Dispose(disposing: false);
+             }
+
+            public void Dispose()
+            {
+                Dispose(disposing: true);
+                GC.SuppressFinalize(this);
+            }
+        }
+    }
+}

--- a/src/GCRealTimeMon/Service/Interfaces.cs
+++ b/src/GCRealTimeMon/Service/Interfaces.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Analysis.GC;
+using System;
+
+namespace realmon.Service
+{
+    internal interface IGCRealTimeMonService
+    {
+        IGCRealTimeMonResult Initialize(int pid, Configuration.Configuration configuration);
+    }
+
+    internal interface IGCRealTimeMonResult : IDisposable
+    {
+        TraceEventDispatcher Source { get; }
+        IObservable<TraceGC> GCEndObservable { get; }
+    }
+}

--- a/src/dotnet-gcmon/dotnet-gcmon.csproj
+++ b/src/dotnet-gcmon/dotnet-gcmon.csproj
@@ -37,6 +37,8 @@
     <Compile Include="..\GCRealTimeMon\Utilities\PlatformUtilities.cs" Link="Utilities\PlatformUtilities.cs" />
     <Compile Include="..\GCRealTimeMon\Utilities\PrintUtilities.cs" Link="Utilities\PrintUtilities.cs" />
     <Compile Include="..\GCRealTimeMon\Utilities\CommandLineUtilities.cs" Link="Utilities\CommandLineUtilities.cs" />
+    <Compile Include="..\GCRealTimeMon\Service\GCRealTimeMonService.cs" Link="Service\GCRealTimeMonService.cs" />
+    <Compile Include="..\GCRealTimeMon\Service\Interfaces.cs" Link="Service\Interfaces.cs" />
   </ItemGroup>
 
   <!--add LICENCE.txt file to the package (PackageLicenceUlr no more supported)-->
@@ -50,6 +52,7 @@
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.251802" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.74" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="Sharprompt" Version="2.3.7" />
   </ItemGroup>
 


### PR DESCRIPTION
In an effort to separate out the core logic for:

__1. Better testability__
    - Adding functional tests will be easier now that we have removed the Console App based calls from the service.
    - Performance testing will also be much easier as it'll be easier to concoct up benchmarking + scenario based perf testing.
__2. Better extensibility such as changing the presentation__
    - Envisioning different presentations can be built on top of the service such as that of a CSV file output or XAML based presentation.
    - By encapsulating the GCEnd logic into a simple Observable, we can start building more automated analysis tools (got a # of ideas here and will be happy to discuss via a PR).

We moved the core logic of the ``GCEnd`` event into it's own abstraction - the GCRealTimeMonService that's accessed via the ``IGCRealTimeMonService`` interface. The contract from the client of the service is to subscribe to the GCEndObservable to obtain the GCEnd events in realtime and call dispose on the ``IGCRealTimeMonResult`` once the program is to exit. 

__Usage__:

```
      IGCRealTimeMonResult result = GCRealTimeMonService.Instance.Value.Initialize(pid: pid, configuration: configuration);
      
      IDisposable subscriptionHandle = result.GCEndObservable.Subscribe(gc =>
      {
          lock (writerLock)
          {
              Console.WriteLine(PrintUtilities.GetRowDetails(gc, configuration));
          }
      });

      result.Source.Process();
```

__When the process needs to exit__:

```
result.Dispose();
```