### PR TITLE
Fix trimming issue

### DIFF
--- a/src/GCRealTimeMon/Directory.Build.props
+++ b/src/GCRealTimeMon/Directory.Build.props
@@ -7,6 +7,8 @@
     <IlcTrimMetadata>true</IlcTrimMetadata>
     <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>None</DebugType>
   </PropertyGroup>
   <ItemGroup Condition="'$(AotCompilation)'=='true'">
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" />

--- a/src/GCRealTimeMon/GCRealTimeMon.csproj
+++ b/src/GCRealTimeMon/GCRealTimeMon.csproj
@@ -32,4 +32,8 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <TrimmerRootAssembly Include="GCRealTimeMon" />
+  </ItemGroup>
+
 </Project>

--- a/src/GCRealTimeMon/rd.xml
+++ b/src/GCRealTimeMon/rd.xml
@@ -3,5 +3,7 @@
         <Assembly Name="System.Private.CoreLib">
             <Type Name="System.Collections.Generic.List`1[[System.String, System.Private.CoreLib]]" Dynamic="Required All" />
         </Assembly>
+        <Assembly Name="GCRealTimeMon" Dynamic="Required All">
+        </Assembly>
     </Application>
 </Directives>


### PR DESCRIPTION
- Prevent assembly `GCRealTimeMon` from trimming
- Suppress debug symbols while building with NativeAOT