### PR TITLE
Added a new column representing accumulative gc pause %

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Currently, the available columns are:
 | LOH frag ratio         | The % of fragmentation on the large object heap (LOH) at the end of this GC.                                                                                                     | `TraceGC.GenFragmentationPercent(Gens.LargeObj)`                                          |
 | finalize promoted (mb) | The size of finalizable objects that were discovered to be dead and so promoted during this GC, in MB.                                                                           | `TraceGC.HeapStats.FinalizationPromotedSize / 1000000.0`                                  |
 | pinned objects         | Number of pinned objects observed in this GC.                                                                                                                                    | `TraceGC.HeapStats.PinnedObjectCount`                                                     |
+| accumulated gc pause % | The percentage of accumulative time spent in GC Pauses since the start of the monitoring.                                                                                                                          | CumulativeSum(`TraceGC.PauseDurationMSec`) / Total Elapsed Time Since Start of Monitoring * 100%                                                     |
 
 ## Call Stacks
 
@@ -142,7 +143,7 @@ The process to add a new column from the ``TraceGC`` event is the following:
 2. Define a ``ColumnInfo`` object in the ``ColumnInfoMap`` with the following properties:
    1. The name
    2. Alignment
-   3. A ``Func<TraceGC, object>`` that looks up an object in via a ``TraceGC`` event.
+   3. A ``Func<CapturedGCEvent, object>`` that contains a ``TraceGC`` event with the relevant GC information. 
    4. Format (optional)
 3. Optionally add corresponding unit tests.
 4. Update the documentation here with the new column.

--- a/src/GCRealTimeMon/DefaultConfig.yaml
+++ b/src/GCRealTimeMon/DefaultConfig.yaml
@@ -9,6 +9,7 @@
     - LOH size (mb) 
     - peak/after
     - gen2 size (mb)
+    - accumulated gc pause %
 
 available_columns:
     # all columns available to be displayed.
@@ -43,3 +44,4 @@ available_columns:
     # Finalized and Pinned
     - finalize promoted (mb)              # The size of finalizable objects that were discovered to be dead and so promoted during this GC, in MB. 
     - pinned objects                      # Number of pinned objects this GC promoted.
+    - accumulated gc pause %              # The percentage of accumulative time spent in GC Pauses since the start of the monitoring.

--- a/src/GCRealTimeMon/Utilities/CapturedGCEvent.cs
+++ b/src/GCRealTimeMon/Utilities/CapturedGCEvent.cs
@@ -8,5 +8,7 @@ namespace realmon.Utilities
     {
         public DateTime Time { get; set; }
         public TraceGC Data { get; set; }
+        public double CumulativePauseTimeMSec { get; set; }
+        public double CumulativeProcessMonitoringTimeMSec { get; set; }
     }
 }

--- a/src/GCRealTimeMon/Utilities/ColumnInfo.cs
+++ b/src/GCRealTimeMon/Utilities/ColumnInfo.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Diagnostics.Tracing.Analysis.GC;
-using System;
+﻿using System;
 
 namespace realmon.Utilities
 {
@@ -9,7 +8,7 @@ namespace realmon.Utilities
     internal sealed class ColumnInfo
     {
         public ColumnInfo(string name,
-                          Func<TraceGC, object> getColumnValueFromEvent,
+                          Func<CapturedGCEvent, object> getColumnValueFromEvent,
                           int? alignment = null,
                           string format = "",
                           string description = "")
@@ -24,7 +23,7 @@ namespace realmon.Utilities
 
         public string Name   { get; }
         public int Alignment { get; }
-        public Func<TraceGC, object> GetColumnValueFromEvent { get; }
+        public Func<CapturedGCEvent, object> GetColumnValueFromEvent { get; }
         public string Format { get; }
         public string Description { get; }
     }

--- a/src/GCRealTimeMon/Utilities/ColumnInfoMap.cs
+++ b/src/GCRealTimeMon/Utilities/ColumnInfoMap.cs
@@ -24,17 +24,17 @@ namespace realmon.Utilities
                 new ColumnInfo(name: $"{gen} size (mb)",
                                format: "N3",
                                description: $"Size of {gen} at the end of this GC in MB.",
-                               getColumnValueFromEvent: (traceEvent) => traceEvent.GenSizeAfterMB(generation));
+                               getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.GenSizeAfterMB(generation));
             Map[$"{gen} survival rate"] =
                 new ColumnInfo(name: $"{gen} survival rate",
                                format: "N0",
                                description: $"The % of objects in {gen} that survived this GC.",
-                               getColumnValueFromEvent: (traceEvent) => traceEvent.SurvivalPercent(generation));
+                               getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.SurvivalPercent(generation));
             Map[$"{gen} frag ratio"] =
                 new ColumnInfo(name: $"{gen} frag ratio",
                                format: "N0",
                                description: $"The % of fragmentation on {gen} at the end of this GC.",
-                               getColumnValueFromEvent: (traceEvent) => traceEvent.GenFragmentationPercent(generation));
+                               getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.GenFragmentationPercent(generation));
         }
 
         /// <summary>
@@ -47,72 +47,76 @@ namespace realmon.Utilities
                 { "index", new ColumnInfo(name: "index",
                                           alignment: 10,
                                           description: "The GC Index.",
-                                          getColumnValueFromEvent: (traceEvent) => traceEvent.Number )},
+                                          getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.Number )},
 
                 // Additional Columns
                 { "type",  new ColumnInfo(name: "type",
                                           alignment: 15,
                                           description: "The Type of GC.",
-                                          getColumnValueFromEvent: (traceEvent) => traceEvent.Type )},
+                                          getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.Type )},
                 { "gen", new ColumnInfo(name: "gen",
                                         alignment: 5,
                                         description: "The Generation",
-                                        getColumnValueFromEvent: (traceEvent) => traceEvent.Generation )},
+                                        getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.Generation )},
                 { "pause (ms)", new ColumnInfo(name: "pause (ms)",
                                                format: "N2",
                                                alignment: 10,
                                                description: "The time managed threads were paused during this GC, in milliseconds",
-                                               getColumnValueFromEvent: (traceEvent) => traceEvent.PauseDurationMSec )},
+                                               getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.PauseDurationMSec )},
                 { "reason", new ColumnInfo(name: "reason",
                                            alignment: 21,
                                            description: "Reason for GC.",
-                                           getColumnValueFromEvent: (traceEvent) => traceEvent.Reason )},
+                                           getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.Reason )},
 
                 { "suspension time (ms)", new ColumnInfo(name: "suspension time (ms)",
                                                          format: "N3",
                                                          description: "The time in milliseconds that it took to suspend all threads to start this GC ",
-                                                         getColumnValueFromEvent: (traceEvent) => traceEvent.SuspendDurationMSec )},
+                                                         getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.SuspendDurationMSec )},
 
-                { "pause time (%)", new ColumnInfo(name: "pause time (%)", 
+                { "pause time (%)", new ColumnInfo(name: "pause time (%)",
                                                    format: "N1",
                                                    description: "The amount of time that execution in managed code is blocked because the GC needs exclusive use to the heap. For background GCs this is small.",
-                                                   getColumnValueFromEvent: (traceEvent) => traceEvent.PauseTimePercentageSinceLastGC )},
+                                                   getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.PauseTimePercentageSinceLastGC )},
 
                 { "gen0 alloc (mb)", new ColumnInfo(name: "gen0 alloc (mb)",
                                                     format: "N3",
                                                     description: "Amount allocated in Gen0 since the last GC occurred in MB.",
-                                                    getColumnValueFromEvent: (traceEvent) => traceEvent.UserAllocated[(int)Gens.Gen0] )},
+                                                    getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.UserAllocated[(int)Gens.Gen0] )},
                 { "gen0 alloc rate", new ColumnInfo(name: "gen0 alloc rate",
                                                     format: "N2",
                                                     description: " The average allocation rate since the last GC.",
-                                                    getColumnValueFromEvent: (traceEvent) =>
+                                                    getColumnValueFromEvent: (capturedGCEvent) =>
                                                     {
-                                                        return (traceEvent.UserAllocated[(int)Gens.Gen0] * 1000.0) / traceEvent.DurationSinceLastRestartMSec;
+                                                        return (capturedGCEvent.Data.UserAllocated[(int)Gens.Gen0] * 1000.0) / capturedGCEvent.Data.DurationSinceLastRestartMSec;
                                                     })},
                 { "peak size (mb)", new ColumnInfo(name: "peak size (mb)",
                                                    format: "N3",
                                                    description: "The size on entry of this GC (includes fragmentation) in MB.",
-                                                   getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizePeakMB)},
+                                                   getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.HeapSizePeakMB)},
                 { "after size (mb)", new ColumnInfo(name: "after size (mb)",
                                                     format: "N3",
                                                     description: "The size on exit of this GC (includes fragmentation) in MB.",
-                                                    getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizeAfterMB )},
+                                                    getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.HeapSizeAfterMB )},
                 { "peak/after", new ColumnInfo(name: "peak/after",
                                                format: "N2",
                                                description: "Peak / After",
-                                               getColumnValueFromEvent: (traceEvent) => traceEvent.HeapSizePeakMB / traceEvent.HeapSizeAfterMB )},
+                                               getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.HeapSizePeakMB / capturedGCEvent.Data.HeapSizeAfterMB )},
                 { "promoted (mb)", new ColumnInfo(name: "promoted (mb)",
                                                   format: "N3",
                                                   description: "Memory this GC promoted in MB.",
-                                                  getColumnValueFromEvent: (traceEvent) => traceEvent.PromotedMB )},
+                                                  getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.PromotedMB )},
                 { "finalize promoted (mb)", new ColumnInfo(name: "finalize promoted (mb)",
                                                            format: "N2",
                                                            description: "The size of finalizable objects that were discovered to be dead and so promoted during this GC, in MB.",
-                                                           getColumnValueFromEvent: (traceEvent) => traceEvent.HeapStats.FinalizationPromotedSize / 1000000.0 )},
+                                                           getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.HeapStats.FinalizationPromotedSize / 1000000.0 )},
                 { "pinned objects", new ColumnInfo(name: "pinned objects",
                                                    format: "N0",
                                                    description: "Number of pinned objects observed in this GC.",
-                                                   getColumnValueFromEvent: (traceEvent) => traceEvent.HeapStats.PinnedObjectCount )},
+                                                   getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.Data.HeapStats.PinnedObjectCount )},
+                { "accumulated gc pause %", new ColumnInfo(name: "accumulated gc pause %",
+                                                   format: "N3",
+                                                   description: "The percentage of accumulative time spent in GC Pauses since the start of the monitoring. i.e. Cumulative GC Pause Duration / Total Elapsed Time * 100%",
+                                                   getColumnValueFromEvent: (capturedGCEvent) => capturedGCEvent.CumulativePauseTimeMSec / capturedGCEvent.CumulativeProcessMonitoringTimeMSec * 100.0 )},
             };
     }
 }

--- a/src/GCRealTimeMon/Utilities/IConsoleOut.cs
+++ b/src/GCRealTimeMon/Utilities/IConsoleOut.cs
@@ -12,7 +12,7 @@ namespace realmon.Utilities
     {
         void WriteProcessInfo(string processName, int pid);
         void WriteLineSeparator();
-        void WriteRow(TraceGC gc);
+        void WriteRow(CapturedGCEvent gc);
         void WriteTableHeaders();
         Task PrintLastStatsAsync(CapturedGCEvent lastGC);
         Task PrintCallStack(TraceCallStack callstack, string eventName);

--- a/src/GCRealTimeMon/Utilities/LiveOutputTable.cs
+++ b/src/GCRealTimeMon/Utilities/LiveOutputTable.cs
@@ -95,7 +95,7 @@ namespace realmon.Utilities
         /// </summary>
         /// <param name="gc">The trace GC data to write.</param>
         /// <returns>A task indicating completion.</returns>
-        public void WriteRow(TraceGC gc)
+        public void WriteRow(CapturedGCEvent gc)
         {
             List<string> rowDetails = PrintUtilities.GetRowDetailsList(gc, this.configuration);
             bool wasWritten = channel.Writer.TryWrite(rowDetails);

--- a/src/GCRealTimeMon/Utilities/PlainTextConsoleOut.cs
+++ b/src/GCRealTimeMon/Utilities/PlainTextConsoleOut.cs
@@ -39,7 +39,7 @@ namespace realmon.Utilities
             Console.WriteLine(PrintUtilities.LineSeparator);
         }
 
-        public void WriteRow(TraceGC gc)
+        public void WriteRow(CapturedGCEvent gc)
         {
             lock (writerLock)
             {

--- a/src/GCRealTimeMon/Utilities/PrintUtilities.cs
+++ b/src/GCRealTimeMon/Utilities/PrintUtilities.cs
@@ -103,16 +103,16 @@ namespace realmon.Utilities
         /// <param name="traceEvent"></param>
         /// <param name="configuration"></param>
         /// <returns></returns>
-        public static string GetRowDetails(TraceGC traceEvent, Configuration.Configuration configuration)
+        public static string GetRowDetails(CapturedGCEvent capturedGCEvent, Configuration.Configuration configuration)
         {
             StringBuilder stringBuilder = new StringBuilder();
             // Add the `index` column.
-            stringBuilder.Append($"GC#{FormatBasedOnColumnAndGCEvent(traceEvent, "index")} |");
+            stringBuilder.Append($"GC#{FormatBasedOnColumnAndGCEvent(capturedGCEvent, "index")} |");
 
             // Iterate through all columns in the config.
             foreach (var columnName in configuration.Columns)
             {
-                stringBuilder.Append($" {FormatBasedOnColumnAndGCEvent(traceEvent, columnName)} |");
+                stringBuilder.Append($" {FormatBasedOnColumnAndGCEvent(capturedGCEvent, columnName)} |");
             }
 
             return stringBuilder.ToString();
@@ -124,7 +124,7 @@ namespace realmon.Utilities
         /// <param name="traceEvent"></param>
         /// <param name="configuration"></param>
         /// <returns></returns>
-        public static List<string> GetRowDetailsList(TraceGC traceEvent, Configuration.Configuration configuration)
+        public static List<string> GetRowDetailsList(CapturedGCEvent traceEvent, Configuration.Configuration configuration)
         {
             List<string> rowDetails = new List<string>();
             // Add the `index` column.
@@ -146,13 +146,13 @@ namespace realmon.Utilities
         /// <param name="columnName"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
-        public static string FormatBasedOnColumnAndGCEvent(TraceGC traceEvent, string columnName)
+        public static string FormatBasedOnColumnAndGCEvent(CapturedGCEvent capturedGCEvent, string columnName)
         {
             if (ColumnInfoMap.Map.TryGetValue(columnName, out var columnInfo))
             {
                 // Full Format: {index, alignment: format}
                 string format = "{0," + columnInfo.Alignment + (string.IsNullOrEmpty(columnInfo.Format) ? string.Empty : $":{columnInfo.Format}") + "}";
-                string formattedString = string.Format(format, columnInfo.GetColumnValueFromEvent(traceEvent));
+                string formattedString = string.Format(format, columnInfo.GetColumnValueFromEvent(capturedGCEvent));
                 return formattedString;
             }
 
@@ -166,9 +166,9 @@ namespace realmon.Utilities
         /// <param name="columnName"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
-        public static string FormatThemeBasedOnColumnAndGCEvent(TraceGC traceEvent, string columnName)
+        public static string FormatThemeBasedOnColumnAndGCEvent(CapturedGCEvent gcEvent, string columnName)
         {
-            string color = traceEvent.Generation switch
+            string color = gcEvent.Data.Generation switch
             {
                 0 => $"[{ThemeConfig.Current.Gen0RowColor}]",
                 1 => $"[{ThemeConfig.Current.Gen1RowColor}]",
@@ -180,7 +180,7 @@ namespace realmon.Utilities
             {
                 // No alignment here as that is taken care of by the table formatting
                 string format = $"{color}{{0" + (string.IsNullOrEmpty(columnInfo.Format) ? string.Empty : $":{columnInfo.Format}") + "}[/]";
-                string formattedString = string.Format(format, columnInfo.GetColumnValueFromEvent(traceEvent));
+                string formattedString = string.Format(format, columnInfo.GetColumnValueFromEvent(gcEvent));
                 return formattedString;
             }
 

--- a/src/GCRealTimeMon/Utilities/SpectreConsoleOut.cs
+++ b/src/GCRealTimeMon/Utilities/SpectreConsoleOut.cs
@@ -41,7 +41,7 @@
 
         public void WriteTableHeaders() => liveOutputTable.Start();
 
-        public void WriteRow(TraceGC gc) => liveOutputTable.WriteRow(gc);
+        public void WriteRow(CapturedGCEvent gc) => liveOutputTable.WriteRow(gc);
 
         /// <summary>
         /// Writes a horizontal rule line with a message in the center to the console.
@@ -160,5 +160,6 @@
             string processIdAsString = selectionPrompt.Show(AnsiConsole.Console);
             return PrintUtilities.ParseProcessIdFromMultiProcessPrompt(processIdAsString);
         }
+
     }
 }

--- a/tests/GCRealTimeMon.UnitTests/PrintUtilities/FormatBasedOnColumnAndGCEvent.cs
+++ b/tests/GCRealTimeMon.UnitTests/PrintUtilities/FormatBasedOnColumnAndGCEvent.cs
@@ -13,7 +13,8 @@ namespace realmon.UnitTests
         public void FormatBasedOnColumnAndGCEvent_GCIndexColumn_SuccessfullyFormatted()
         {
             TraceGC traceGC = new TraceGC(2) { Number = 1 };
-            string resolvedColumn = PrintUtilities.FormatBasedOnColumnAndGCEvent(traceEvent: traceGC, columnName: "index");
+            CapturedGCEvent capturedGCEvent = new CapturedGCEvent { Data = traceGC };
+            string resolvedColumn = PrintUtilities.FormatBasedOnColumnAndGCEvent(capturedGCEvent: capturedGCEvent, columnName: "index");
             resolvedColumn.Should().NotBeNullOrEmpty();
             resolvedColumn.Should().BeEquivalentTo("         1");
         }
@@ -22,7 +23,8 @@ namespace realmon.UnitTests
         public void FormatBasedOnColumnAndGCEvent_TypeInputColumn_SuccessfullyFormatted()
         {
             TraceGC traceGC = new TraceGC(2) { Type = Microsoft.Diagnostics.Tracing.Parsers.Clr.GCType.NonConcurrentGC };
-            string resolvedColumn = PrintUtilities.FormatBasedOnColumnAndGCEvent(traceEvent: traceGC, columnName: "type");
+            CapturedGCEvent capturedGCEvent = new CapturedGCEvent { Data = traceGC };
+            string resolvedColumn = PrintUtilities.FormatBasedOnColumnAndGCEvent(capturedGCEvent: capturedGCEvent, columnName: "type");
             resolvedColumn.Should().NotBeNullOrEmpty();
             resolvedColumn.Should().BeEquivalentTo("NonConcurrentGC");
         }
@@ -31,7 +33,8 @@ namespace realmon.UnitTests
         public void FormatBasedOnColumnAndGCEvent_GenerationColumn_SuccessfullyFormatted()
         {
             TraceGC traceGC = new TraceGC(2) { Generation = 1 };
-            string resolvedColumn = PrintUtilities.FormatBasedOnColumnAndGCEvent(traceEvent: traceGC, columnName: "gen");
+            CapturedGCEvent capturedGCEvent = new CapturedGCEvent { Data = traceGC };
+            string resolvedColumn = PrintUtilities.FormatBasedOnColumnAndGCEvent(capturedGCEvent: capturedGCEvent, columnName: "gen");
             resolvedColumn.Should().NotBeNullOrEmpty();
             resolvedColumn.Should().BeEquivalentTo("    1");
         }
@@ -40,7 +43,8 @@ namespace realmon.UnitTests
         public void FormatBasedOnColumnAndGCEvent_GCPauseColumn_SuccessfullyFormatted()
         {
             TraceGC traceGC = new TraceGC(2) { PauseDurationMSec = 100 };
-            string resolvedColumn = PrintUtilities.FormatBasedOnColumnAndGCEvent(traceEvent: traceGC, columnName: "pause (ms)");
+            CapturedGCEvent capturedGCEvent = new CapturedGCEvent { Data = traceGC };
+            string resolvedColumn = PrintUtilities.FormatBasedOnColumnAndGCEvent(capturedGCEvent: capturedGCEvent, columnName: "pause (ms)");
             resolvedColumn.Should().NotBeNullOrEmpty();
             resolvedColumn.Should().BeEquivalentTo("    100.00");
         }
@@ -49,7 +53,8 @@ namespace realmon.UnitTests
         public void FormatBasedOnColumnAndGCEvent_UnidentifiedColumn_UnsuccessfullyParsedWithException()
         {
             TraceGC traceGC = new TraceGC(2) { PauseDurationMSec = 100 };
-            Action resolveColumn = () => PrintUtilities.FormatBasedOnColumnAndGCEvent(traceEvent: traceGC, columnName: "unregisted");
+            CapturedGCEvent capturedGCEvent = new CapturedGCEvent { Data = traceGC };
+            Action resolveColumn = () => PrintUtilities.FormatBasedOnColumnAndGCEvent(capturedGCEvent: capturedGCEvent, columnName: "unregisted");
             resolveColumn.Should().Throw<ArgumentException>();
         }
     }

--- a/tests/GCRealTimeMon.UnitTests/PrintUtilities/GetRowDetails.cs
+++ b/tests/GCRealTimeMon.UnitTests/PrintUtilities/GetRowDetails.cs
@@ -21,10 +21,12 @@ namespace realmon.UnitTests
                 Reason = Microsoft.Diagnostics.Tracing.Parsers.Clr.GCReason.AllocSmall
             };
 
+            CapturedGCEvent capturedGCEvent = new CapturedGCEvent { Data = traceEvent };
+
             Configuration.Configuration configuration = new Configuration.Configuration();
             configuration.Columns = new List<string> { "type", "gen", "pause (ms)", "reason" };
 
-            string rowDetails = PrintUtilities.GetRowDetails(traceEvent, configuration);
+            string rowDetails = PrintUtilities.GetRowDetails(capturedGCEvent, configuration);
             rowDetails.Should().NotBeNullOrEmpty();
             rowDetails.Should().BeEquivalentTo("GC#       430 | NonConcurrentGC |     0 |       7.38 |            AllocSmall |");
         }


### PR DESCRIPTION
- Added a new column representing accumulative gc pause % computed as: ``Cumulative Sum(TraceGC.PauseDurationMSec) / Total Elapsed Time From The Start of Monitoring * 100%``. 
- Updated the ``ColumnInfoMap`` to now take in a ``CapturedGCEvent`` rather than a ``TraceGC`` that'll help with more customizable calculations that aren't constrained to just ``TraceGC``.
- Added the new column to the DefaultConfig.yaml. 

The addition of the new column with the DefaultConfig.yaml is:

![image](https://user-images.githubusercontent.com/4951960/163709982-cc293108-21dd-4c4d-b1e8-43131803c3e7.png)
